### PR TITLE
exclude redirect pages from the navigation

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,7 @@
   <ul class="navigation-list">
     {%- assign pages_list = site.html_pages | sort:"nav_order" -%}
     {%- for node in pages_list -%}
-    {%- unless node.nav_exclude -%}
+    {%- unless node.nav_exclude or node.layout == "redirect" -%}
     {%- if node.parent == nil -%}
     <li
       class="navigation-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,0 +1,44 @@
+<nav role="navigation" aria-label="Main navigation">
+  <ul class="navigation-list">
+    {%- assign pages_list = site.html_pages | sort:"nav_order" -%}
+    {%- for node in pages_list -%}
+    {%- unless node.nav_exclude -%}
+    {%- if node.parent == nil -%}
+    <li
+      class="navigation-list-item{% if page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
+      {%- if page.parent == node.title or page.grand_parent == node.title -%}
+      {%- assign first_level_url = node.url | absolute_url -%}
+      {%- endif -%}
+      <a href="{{ node.url | absolute_url }}"
+        class="navigation-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
+      {%- if node.has_children -%}
+      {%- assign children_list = site.html_pages | where: "parent", node.title | sort:"nav_order" -%}
+      <ul class="navigation-list-child-list ">
+        {%- for child in children_list -%}
+        <li class="navigation-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
+          {%- if page.url == child.url or page.parent == child.title -%}
+          {%- assign second_level_url = child.url | absolute_url -%}
+          {%- endif -%}
+          <a href="{{ child.url | absolute_url }}"
+            class="navigation-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
+          {%- if child.has_children -%}
+          {%- assign grand_children_list = site.html_pages | where: "parent", child.title | sort:"nav_order" -%}
+          <ul class="navigation-list-child-list">
+            {%- for grand_child in grand_children_list -%}
+            <li class="navigation-list-item {% if page.url == grand_child.url %} active{% endif %}">
+              <a href="{{ grand_child.url | absolute_url }}"
+                class="navigation-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
+            </li>
+            {%- endfor -%}
+          </ul>
+          {%- endif -%}
+        </li>
+        {%- endfor -%}
+      </ul>
+      {%- endif -%}
+    </li>
+    {%- endif -%}
+    {%- endunless -%}
+    {%- endfor -%}
+  </ul>
+</nav>


### PR DESCRIPTION
The redirect plugin creates "fake" pages to make the redirects work. These were included in the navigation.

Also reported upstream at https://github.com/pmarsceill/just-the-docs/issues/240