### PR TITLE
Update exercise config reference

### DIFF
--- a/references/exercise-config/en.md
+++ b/references/exercise-config/en.md
@@ -32,6 +32,7 @@ Dodona allows setting the configuration of an exercise using config files. These
   - `memory_limit` (integer, optional): the amount of memory in bytes that is available for running the evaluation. By default, the limit is 100MB.
   - `network_enabled` (boolean, optional): set to `true` if internet access should be enabled. This optional setting is false by default.
 - `labels` (array of strings, optional): a list of labels that can be used to search for this exercise using the Dodona web interface.
+- `author` (string, optional): info about the author of this exercise, formatted like an email To header.
 
 ## Example config file
 
@@ -46,12 +47,13 @@ Dodona allows setting the configuration of an exercise using config files. These
     }
   },
   "evaluation": {
-    "handler": "pythia",
-    "image": "biopythia",
+    "handler": "python",
+    "image": "dodona/dodona-python",
     "time_limit": 10,
     "memory_limit": 10000000,
     "network_enabled": true
   },
-  "labels": ["voorbeeld", "eenvoudige oefening"]
+  "labels": ["voorbeeld", "eenvoudige oefening"],
+  "author": "Dodona <dodona@ugent.be>"
 }
 ```


### PR DESCRIPTION
Include a description about the author field, and updates the example config file, so that it would work if people just copy-paste it.

Fixes #37.