### PR TITLE
Translate English-only reference pages

### DIFF
--- a/en/references/exercise-config/README.md
+++ b/en/references/exercise-config/README.md
@@ -44,6 +44,8 @@ The structure for a reading activity is identical to that of an exercise. There 
 
 ## Example config file
 
+### Exercise
+
 ```json
 {
   "type": "exercise",
@@ -64,5 +66,21 @@ The structure for a reading activity is identical to that of an exercise. There 
   },
   "labels": ["voorbeeld", "eenvoudige oefening"],
   "contact": "Dodona <dodona@ugent.be>"
+}
+```
+
+### Reading activity
+
+```json
+{
+  "description": {
+    "names": {
+      "en": "Aeneid",
+      "nl": "Aeneis"
+    }
+  },
+  "type": "content",
+  "visibility": "public",
+  "labels": ["test", "intro"]
 }
 ```

--- a/en/references/exercise-config/README.md
+++ b/en/references/exercise-config/README.md
@@ -9,38 +9,38 @@ Dodona allows setting the configuration of an exercise and a reading activity us
 
 ## Config file structure for exercises
 
-- `type`: Must be set to `exercise` for exercises. Defaults to `exercise` if not present
-- `programming_language` (string): the programming language of the exercise, used for syntax highlighting and correct file extensions
-- `access` (`public` or `private`): determines who can use this exercise
+- **`type`**: Must be set to `exercise` for exercises. Defaults to `exercise` if not present
+- **`programming_language`** (string): the programming language of the exercise, used for syntax highlighting and correct file extensions
+- **`access`** (`public` or `private`): determines who can use this exercise
   - public: any other teacher on Dodona can use this exercise
   - private: only teachers with explicit permission can use this exercise
-- `description` (object): the specification of the description of the exercise
-  - `names` (object): the name of the exercise
-    - `nl`: the name of the exercise in Dutch
-    - `en`: the name of the exercise in English
-- `evaluation`: the specification of the evaluation procedure
-  - `handler` (string, optional): the name of the judge that is used for evaluation. By default, Dodona uses the judge specified for the repository.
-  - `image` (string, optional): the name of the docker image that is used for evaluation. By default, Dodona uses the image specified by the judge.
-  - `time_limit` (integer, optional): the time in seconds before the evaluations times out. By default, the limit is 42 seconds.
-  - `memory_limit` (integer, optional): the amount of memory in bytes that is available for running the evaluation. By default, the limit is 100MB.
-  - `network_enabled` (boolean, optional): set to `true` if internet access should be enabled. This optional setting is false by default.
-- `labels` (array of strings, optional): a list of labels that can be used to search for this exercise using the Dodona web interface.
-- `contact` (string, optional): info about the author of this exercise, formatted like an email To header.
+- **`description`** (object): the specification of the description of the exercise
+  - **`names`** (object): the name of the exercise
+    - **`nl`**: the name of the exercise in Dutch
+    - **`en`**: the name of the exercise in English
+- **`evaluation`**: the specification of the evaluation procedure
+  - **`handler`** (string, optional): the name of the judge that is used for evaluation. By default, Dodona uses the judge specified for the repository.
+  - **`image`** (string, optional): the name of the docker image that is used for evaluation. By default, Dodona uses the image specified by the judge.
+  - **`time_limit`** (integer, optional): the time in seconds before the evaluations times out. By default, the limit is 42 seconds.
+  - **`memory_limit`** (integer, optional): the amount of memory in bytes that is available for running the evaluation. By default, the limit is 100MB.
+  - **`network_enabled`** (boolean, optional): set to `true` if internet access should be enabled. This optional setting is false by default.
+- **`labels`** (array of strings, optional): a list of labels that can be used to search for this exercise using the Dodona web interface.
+- **`contact`** (string, optional): info about the author of this exercise, formatted like an email To header.
 
 ## Config file structure for reading activities
 
 The structure for a reading activity is identical to that of an exercise. There are 2 big differences: the value of `type` must be set to `content` and keys that are not relevant for exercises can be omitted. The format of the description is also identical.
 
-- `type`: Must be set to `content` for reading activities
-- `access` (`public` or `private`): determines who can use this exercise
+- **`type`**: Must be set to `content` for reading activities
+- **`access`** (`public` or `private`): determines who can use this exercise
   - public: any other teacher on Dodona can use this exercise
   - private: only teachers with explicit permission can use this exercise
-- `description` (object): the specification of the description of the exercise
-  - `names` (object): the name of the exercise
-    - `nl`: the name of the exercise in Dutch
-    - `en`: the name of the exercise in English
-- `labels` (array of strings, optional): a list of labels that can be used to search for this exercise using the Dodona web interface.
-- `contact` (string, optional): info about the author of this reading activity, formatted like an email To header.
+- **`description`** (object): the specification of the description of the exercise
+  - **`names`** (object): the name of the exercise
+    - **`nl`**: the name of the exercise in Dutch
+    - **`en`**: the name of the exercise in English
+- **`labels`** (array of strings, optional): a list of labels that can be used to search for this exercise using the Dodona web interface.
+- **`contact`** (string, optional): info about the author of this reading activity, formatted like an email To header.
 
 ## Example config file
 

--- a/en/references/exercise-directory-structure/README.md
+++ b/en/references/exercise-directory-structure/README.md
@@ -28,20 +28,20 @@ Dodona ignores every other file and directory. You can thus freely create additi
 ## Example of a valid exercise directory structure
 
 ```
-+-- intsum                     # short name for the exercise
-|   +-- config.json            # configuration of the exercise
++-- intsum                     # Short name for the exercise
+|   +-- config.json            # Configuration of the exercise
 |   +-- evaluation             #
 |   |   +-- intsum_test.hs     # A Haskell test file
 |   +-- description            #
-|   |   +-- description.nl.md  # The description in dutch
-|   |   +-- description.en.md  # The description in english
+|   |   +-- description.nl.md  # The description in Dutch
+|   |   +-- description.en.md  # The description in English
 |   |   +-- media              #
 |   |   |   +-- some_image.png # An image used in the description
 |   |   +-- boilerplate        #
-|   |       +-- boilerplate    # Default (here dutch?) boilerplate code
+|   |       +-- boilerplate    # Default boilerplate code
 |   |       +-- boilerplate.en # English boilerplate code
-|   +-- workdir                # current working dir for student code
-|       +-- intlines.txt       # a file available to the student
+|   +-- workdir                # Current working dir for student code
+|       +-- intlines.txt       # A file available to the student
 :
 ```
 

--- a/nl/references/README.md
+++ b/nl/references/README.md
@@ -10,6 +10,4 @@ Hier vind je up-to-date beschrijvingen van de Dodona configuratiebestanden en ma
 * [Oefeningenbeschrijvingen](exercise-description)
 * [Repository bestandenstructuur](repository-directory-structure)
 * [Oefeningconfiguratie](exercise-config)
-
-## In het Engels
-* [Exercise directory structure](exercise-directory-structure)
+* [Oefeningfolderstructuur](exercise-directory-structure)

--- a/nl/references/README.md
+++ b/nl/references/README.md
@@ -4,10 +4,9 @@ sidebarDepth: 0
 ---
 # Referenties
 
-Hier vind je up-to-date beschrijvingen van de Dodona configuratiebestanden en mappenstructuren.
+Hier vind je up-to-date beschrijvingen van de Dodona configuratiebestanden en mappenstructuren:
 
-## In het Nederlands
 * [Oefeningenbeschrijvingen](exercise-description)
-* [Repository bestandenstructuur](repository-directory-structure)
+* [Repository-structuur](repository-directory-structure)
 * [Oefeningconfiguratie](exercise-config)
-* [Oefeningfolderstructuur](exercise-directory-structure)
+* [Oefeningmap-structuur](exercise-directory-structure)

--- a/nl/references/README.md
+++ b/nl/references/README.md
@@ -9,7 +9,7 @@ Hier vind je up-to-date beschrijvingen van de Dodona configuratiebestanden en ma
 ## In het Nederlands
 * [Oefeningenbeschrijvingen](exercise-description)
 * [Repository bestandenstructuur](repository-directory-structure)
+* [Oefeningconfiguratie](exercise-config)
 
 ## In het Engels
-* [Exercise config](exercise-config)
 * [Exercise directory structure](exercise-directory-structure)

--- a/nl/references/exercise-config/README.md
+++ b/nl/references/exercise-config/README.md
@@ -9,38 +9,38 @@ Dodona laat toe om de configuratie van een oefening of een leesactiviteit in te 
 
 ## Configuratiebestandsstructuur voor oefeningen
 
-- `type`: Moet ingesteld worden op `exercise` voor oefeningen. De standaardwaarde indien afwezig is `exercise`
-- `programming_language` (string): de programmeertaal van de oefening, wordt gebruikt voor syntax highlighting en om de juiste bestandsextensie te bepalen
-- `access` (`public` of `private`): bepaalt wie deze oefening kan gebruiken
+- **`type`**: Moet ingesteld worden op `exercise` voor oefeningen. De standaardwaarde indien afwezig is `exercise`
+- **`programming_language`** (string): de programmeertaal van de oefening, wordt gebruikt voor *syntax highlighting* en om de juiste bestandsextensie te bepalen
+- **`access`** (`public` of `private`): bepaalt wie deze oefening kan gebruiken
   - public: elke lesgever op Dodona kan deze oefening gebruiker
   - private: enkel lesgevers met expliciete toestemming mogen deze oefening gebruiken
-- `description` (object): de specificatie van de beschrijving van deze oefening
-  - `names` (object): de naam van de oefening
-    - `nl`: de naam van de oefening in het Nederlands
+- **`description`** (object): de specificatie van de beschrijving van deze oefening
+  - **`names`** (object): de naam van de oefening
+    - **`nl`**: de naam van de oefening in het Nederlands
     - `en`: de naam van de oefening in het Engels
-- `evaluation`: de specificatie van de evaluatieprocedure
-  - `handler` (string, optioneel): de naam van de judge die gebruikt wordt voor de evaluatie. Standaard gebruik Dodona de judge die ingesteld is voor de repository.
-  - `image` (string, optioneel): de naam van de docker image die gebruikt wordt voor de evaluatie. Standaard gebruikt Dodona de image die ingesteld is voor de judge.
-  - `time_limit` (integer, optioneel): de tijd in seconden waarna de evaluatie van een oefening stopgezet wordt. Standaard is dit 42 seconden
-  - `memory_limit` (integer, optioneel): de hoeveelheid geheugen in bytes die gebruikt kan worden bij het uitvoeren van de eevaluatie. Standaard is dit ingesteld op 100M.
-  - `network_enabled` (boolean, optioneel): ingesteld op `true` als toegang tot het internet toegelaten is. Standaard staat deze waarde op `false`.
-- `labels` (lijst van strings, optioneel): een lijst van labels die gebruikt kunnen worden om deze oefening te vinden via de Dodona web interface. Standaard een lege lijst.
-- `contact` (string, optioneel): informatie over de auteur van deze oefening, geformatteerd zoals een email-ontvanger hoofding.
+- **`evaluation`**: de specificatie van de evaluatieprocedure
+  - **`handler`** (string, optioneel): de naam van de judge die gebruikt wordt voor de evaluatie. Standaard gebruik Dodona de judge die ingesteld is voor de repository.
+  - **`image`** (string, optioneel): de naam van de docker image die gebruikt wordt voor de evaluatie. Standaard gebruikt Dodona de image die ingesteld is voor de judge.
+  - **`time_limit`** (integer, optioneel): de tijd in seconden waarna de evaluatie van een oefening stopgezet wordt. Standaard is dit 42 seconden
+  - **`memory_limit`** (integer, optioneel): de hoeveelheid geheugen in bytes die gebruikt kan worden bij het uitvoeren van de eevaluatie. Standaard is dit ingesteld op 100M.
+  - **`network_enabled`** (boolean, optioneel): ingesteld op `true` als toegang tot het internet toegelaten is. Standaard staat deze waarde op `false`.
+- **`labels`** (lijst van strings, optioneel): een lijst van labels die gebruikt kunnen worden om deze oefening te vinden via de Dodona web interface. Standaard een lege lijst.
+- **`contact`** (string, optioneel): informatie over de auteur van deze oefening, geformatteerd zoals een email-ontvanger hoofding.
 
 ## Configuratiebestandsstructuur voor leesactiviteiten
 
 De structuur voor een leesactiviteit is identiek aan deze van een oefening. Er zijn echter 2 grote verschillen: de waarde van `type` moet ingesteld worden op `content` en bepaalde verplichte velden zoals `programming_language` mogen achterwege gelaten worden.
 
-- `type`: Moet ingesteld worden op `content` voor leesctiviteiten.
-- `access` (`public` of `private`): bepaalt wie deze oefening kan gebruiken
+- **`type`**: Moet ingesteld worden op `content` voor leesctiviteiten.
+- **`access`** (`public` of `private`): bepaalt wie deze oefening kan gebruiken
   - public: elke lesgever op Dodona kan deze oefening gebruiker
   - private: enkel lesgevers met expliciete toestemming mogen deze oefening gebruiken
-- `description` (object): de specificatie van de beschrijving van deze oefening
-  - `names` (object): de naam van de oefening
-    - `nl`: de naam van de oefening in het Nederlands
-    - `en`: de naam van de oefening in het Engels
-- `labels` (lijst van strings, optioneel): een lijst van labels die gebruikt kunnen worden om deze oefening te vinden via de Dodona web interface. Standaard een lege lijst.
-- `contact` (string, optioneel): informatie over de auteur van deze oefening, geformatteerd zoals een email-ontvanger hoofding.
+- **`description`** (object): de specificatie van de beschrijving van deze oefening
+  - **`names`** (object): de naam van de oefening
+    - **`nl`**: de naam van de oefening in het Nederlands
+    - **`en`**: de naam van de oefening in het Engels
+- **`labels`** (lijst van strings, optioneel): een lijst van labels die gebruikt kunnen worden om deze oefening te vinden via de Dodona web interface. Standaard een lege lijst.
+- **`contact`** (string, optioneel): informatie over de auteur van deze oefening, geformatteerd zoals een email-ontvanger hoofding.
 
 ## Voorbeeld configuratiebestand
 

--- a/nl/references/exercise-config/README.md
+++ b/nl/references/exercise-config/README.md
@@ -1,48 +1,50 @@
 ---
-title: "[en] Exercise config"
-description: "Exercise config reference Dodona"
+title: "Oefeningconfiguratie"
+description: "Oefeningconfiguratie op Dodona"
 ---
 
-# Exercise configuration
+# Oefeningconfiguratie
 
-Dodona allows setting the configuration of an exercise or a reading activity using config files. These files are in the JSON format and must be named `config.json` in exercise directories and `dirconfig.json` for other directories. To determine the final config values for a learning activity, Dodona merges the default config file with the dirconfigs in the parent directories of the exercise and with the exercise config. Merging happens in such a way that you can always override values set in a parent directory.
+Dodona laat toe om de configuratie van een oefening of een leesactiviteit in te stellen door middel van configuratiebestanden. Deze bestanden moeten het JSON-formaat hebben en `config.json` genoemd worden in oefeningenfolders en `dirconfig.json` in andere folders. Om de finale configuratiewaarden te bekomen voor een leeractiviteit, voegt Dodona het standaardconfiguratiebestand samen met de dirconfigs in de bovenliggende folders van de oefening en met het oefeningconfiguratiebestand. Dit proces laat je toe om waarden in een bovenliggende folder te overschrijven.
 
-## Config file structure for exercises
+## Configuratiebestandsstructuur voor oefeningen
 
-- `type`: Must be set to `exercise` for exercises. Defaults to `exercise` if not present
-- `programming_language` (string): the programming language of the exercise, used for syntax highlighting and correct file extensions
-- `access` (`public` or `private`): determines who can use this exercise
-  - public: any other teacher on Dodona can use this exercise
-  - private: only teachers with explicit permission can use this exercise
-- `description` (object): the specification of the description of the exercise
-  - `names` (object): the name of the exercise
-    - `nl`: the name of the exercise in Dutch
-    - `en`: the name of the exercise in English
-- `evaluation`: the specification of the evaluation procedure
-  - `handler` (string, optional): the name of the judge that is used for evaluation. By default, Dodona uses the judge specified for the repository.
-  - `image` (string, optional): the name of the docker image that is used for evaluation. By default, Dodona uses the image specified by the judge.
-  - `time_limit` (integer, optional): the time in seconds before the evaluations times out. By default, the limit is 42 seconds.
-  - `memory_limit` (integer, optional): the amount of memory in bytes that is available for running the evaluation. By default, the limit is 100MB.
-  - `network_enabled` (boolean, optional): set to `true` if internet access should be enabled. This optional setting is false by default.
-- `labels` (array of strings, optional): a list of labels that can be used to search for this exercise using the Dodona web interface.
-- `contact` (string, optional): info about the author of this exercise, formatted like an email To header.
+- `type`: Moet ingesteld worden op `exercise` voor oefeningen. De standaardwaarde indien afwezig is `exercise`
+- `programming_language` (string): de programmeertaal van de oefening, wordt gebruikt voor syntax highlighting en om de juiste bestandsextensie te bepalen
+- `access` (`public` of `private`): bepaalt wie deze oefening kan gebruiken
+  - public: elke lesgever op Dodona kan deze oefening gebruiker
+  - private: enkel lesgevers met expliciete toestemming mogen deze oefening gebruiken
+- `description` (object): de specificatie van de beschrijving van deze oefening
+  - `names` (object): de naam van de oefening
+    - `nl`: de naam van de oefening in het Nederlands
+    - `en`: de naam van de oefening in het Engels
+- `evaluation`: de specificatie van de evaluatieprocedure
+  - `handler` (string, optioneel): de naam van de judge die gebruikt wordt voor de evaluatie. Standaard gebruik Dodona de judge die ingesteld is voor de repository.
+  - `image` (string, optioneel): de naam van de docker image die gebruikt wordt voor de evaluatie. Standaard gebruikt Dodona de image die ingesteld is voor de judge.
+  - `time_limit` (integer, optioneel): de tijd in seconden waarna de evaluatie van een oefening stopgezet wordt. Standaard is dit 42 seconden
+  - `memory_limit` (integer, optioneel): de hoeveelheid geheugen in bytes die gebruikt kan worden bij het uitvoeren van de eevaluatie. Standaard is dit ingesteld op 100M.
+  - `network_enabled` (boolean, optioneel): ingesteld op `true` als toegang tot het internet toegelaten is. Standaard staat deze waarde op `false`.
+- `labels` (lijst van strings, optioneel): een lijst van labels die gebruikt kunnen worden om deze oefening te vinden via de Dodona web interface. Standaard een lege lijst.
+- `contact` (string, optioneel): informatie over de auteur van deze oefening, geformatteerd zoals een email-ontvanger hoofding.
 
-## Config file structure for reading activities
+## Configuratiebestandsstructuur voor leesactiviteiten
 
-The structure for a reading activity is identical to that of an exercise. There are 2 big differences: the value of `type` must be set to `content` and keys that are not relevant for exercises can be omitted. The format of the description is also identical.
+De structuur voor een leesactiviteit is identiek aan deze van een oefening. Er zijn echter 2 grote verschillen: de waarde van `type` moet ingesteld worden op `content` en bepaalde verplichte velden zoals `programming_language` mogen achterwege gelaten worden.
 
-- `type`: Must be set to `content` for reading activities
-- `access` (`public` or `private`): determines who can use this exercise
-  - public: any other teacher on Dodona can use this exercise
-  - private: only teachers with explicit permission can use this exercise
-- `description` (object): the specification of the description of the exercise
-  - `names` (object): the name of the exercise
-    - `nl`: the name of the exercise in Dutch
-    - `en`: the name of the exercise in English
-- `labels` (array of strings, optional): a list of labels that can be used to search for this exercise using the Dodona web interface.
-- `contact` (string, optional): info about the author of this reading activity, formatted like an email To header.
+- `type`: Moet ingesteld worden op `content` voor leesctiviteiten.
+- `access` (`public` of `private`): bepaalt wie deze oefening kan gebruiken
+  - public: elke lesgever op Dodona kan deze oefening gebruiker
+  - private: enkel lesgevers met expliciete toestemming mogen deze oefening gebruiken
+- `description` (object): de specificatie van de beschrijving van deze oefening
+  - `names` (object): de naam van de oefening
+    - `nl`: de naam van de oefening in het Nederlands
+    - `en`: de naam van de oefening in het Engels
+- `labels` (lijst van strings, optioneel): een lijst van labels die gebruikt kunnen worden om deze oefening te vinden via de Dodona web interface. Standaard een lege lijst.
+- `contact` (string, optioneel): informatie over de auteur van deze oefening, geformatteerd zoals een email-ontvanger hoofding.
 
-## Example config file
+## Voorbeeld configuratiebestand
+
+### Oefening
 
 ```json
 {
@@ -64,5 +66,21 @@ The structure for a reading activity is identical to that of an exercise. There 
   },
   "labels": ["voorbeeld", "eenvoudige oefening"],
   "contact": "Dodona <dodona@ugent.be>"
+}
+```
+
+### Leesactiviteit
+
+```json
+{
+  "description": {
+    "names": {
+      "en": "Aeneid",
+      "nl": "Aeneis"
+    }
+  },
+  "type": "content",
+  "visibility": "public",
+  "labels": ["test", "intro"]
 }
 ```

--- a/nl/references/exercise-directory-structure/README.md
+++ b/nl/references/exercise-directory-structure/README.md
@@ -1,60 +1,60 @@
 ---
-title: "[en] Exercise directory structure"
-description: "Exercise directory structure Dodona"
+title: "Oefeningfolderstructuur"
+description: "Oefeningfolderstructuur Dodona"
 ---
 
-# Exercise directory structure
+# Oefeningfolderstructuur
 
-Inside an exercise repository, Dodona handles every directory containing a `config.json` file as a separate learning activity: this can be a programming exercise or a reading activity. We expect this directory to have a specific structure:
+Binnenin een oefeningenfolder behandelt Dodona elke folder met een `config.json`-bestand als een aparte leeractiviteit: dit kan een programmeeroefening zijn of een leesactiviteit. We verwachten dat deze folder de volgende structuur heeft: 
 
-- **A `config.json` file**: this file contains the [exercise-specific configuration](/en/references/exercise-config). This configuration will be merged with all `dirconfig.json` files in the exercise's ancestor directories. You can always override config values set by a higher directory. 
-- **An optional  `readme.md`, `readme.en.md` and/or `readme.nl.md` file:** The content of these files will be shown on the exercise info page. These files are meant to give extra context to teachers who might be interested in using this exercise in a course. If a localized file is available for a user's language (`readme.<lang>.md`) that will be shown instead of the generic `readme.md`. This is useful because `readme.md` is rendered and shown by GitHub in the exercise directory. We suggest creating a `readme.md` in the language of your target audience and optionally creating a translated `readme.nl.md` or `readme.en.md` file in the other language. Take a look at the [example exercises repository](https://github.com/dodona-edu/example-exercises) to see some examples on how to use these files.
-- **A `description` directory**: this directory contains the files describing the exercise containing:
-  - **A `description.en.md` and/or `description.nl.md` file**: these files contain the English and/or Dutch description of the exercise.
+- **Een `config.json`-bestand**: dit bestand bevat de[oefening-specifieke configuratie](../exercise-config). Deze configuratie zal samengevoegd worden met alle `dirconfig.json`-bestanden in de bovenliggende folder van de oefeningfolder. Je kan altijd configuratiewaarden die ingesteld werden door een bovenliggende folder overschrijven. 
+- **Een optioneel `readme.md`-, `readme.en.md`- en/of `readme.nl.md`-bestand:** De inhoud van deze bestanden zal getoond worden op de oefening-infopagina.Deze bestanden hebben als doel extra informatie geven aan leerkrachten die deze oefening misschien willen gebruiken in een cursus. Als er een bestand beschikbaar is in de taal van de gebruiker (`readme.<taal>.md`), dan zal deze getoond worden in plaats van het generieke `readme.md`-bestand. Dit is nuttig omdat `readme.md` getoond wordt door GitHub in de oefeningfolder. We suggereren om een `readme.md`-bestand te maken in de taal van je doelpubliek en dit optioneeel te vertalen door `readme.nl.md` of `readme.en.md` te voorzien. Neem een kijkje in de [voorbeeldoefeningenrepository](https://github.com/dodona-edu/example-exercises) om een voorbeeld te vinden van hoe je deze bestanden gebruikt.
+- **Een `description`-folder**: deze folder bevat de volgende bestanden die de oefening beschrijven:
+  - **Een `description.en.md`- en/of `description.nl.md`-bestand**: deze bestanden bevatten de Engelse en/of Nederlandse beschrijving van de oefening.
 
 
-## Exercise-only configuration
+## Oefening-specifieke configuratie
 
-These directories are only relevant for programming exercises.
-Inside the `description` directory, you can specify the following directories:
-- **An optional `media` directory**: this directory contains static files such as images used in the exercise description.
-- **An optional `boilerplate` directory**: this directory contains the files `boilerplate.en`, `boilerplate.nl`, and/or `boilerplate`. The contents of these files are loaded automatically in the submission text area of the users. You can use this to provide some starting code or structure to your students.
-- **An `evaluation` directory**: the content of this directory is made available to the judge and can, for example, contain files containing the test code.
-- **An optional `workdir` directory**: The content of this directory is made available when running the judge and can, for example, contain data files needed during execution.
-- **An optional `solutions` directory**: Files in this directory will be shown on the exercise info page as sample solutions. Multiple sample solutions are possible, but files with a name starting with 'solution' will be sorted first.
+Deze folders zijn enkel relevant voor programmeeroefeningen
+Binnenin de `description`-folder kan je volgende folders specifiëren:
+- **Een optionele `media`-folder**: deze folder bevat statische bestanden zoals afbeeldingen die gebruikt worden in de oefeningbeschrijving.
+- **Een optionele `boilerplate`-folder**: deze folder bevat de bestanden `boilerplate.en`, `boilerplate.nl`, en/of `boilerplate`. De inhoud van deze bestanden worden automatisch ingeladen in het inzendingstekstveld van de gebruikers. Je kan deze bestanden gebruiken om startcode of structuur te voorzien voor de studenten.
+- **Een `evaluation`-folder**: de inhoud van deze folder wordt beschikbaar gesteld voor de judge en kan bijvoorbeeld bestanden met de testcode bevatten.
+- **Een optionele `workdir`-folder**: de inhoud van deze folder worddt beschikbaar gesteld tijdens het uitvoeren van de judge en kan bijvoorbeeld databestanden bevatten die nodig zijn tijdens het uitvoeren van de tests.
+- **Een optionele `solutions`-folder**: bestanden in deze folder zullen getoond worden op de oefening-informatiepagina als voorbeeldoplossing. Meerdere voorbeeldoplossingen zijn mogelijk, maar bestanden met een naam beginnend met 'solution' zullen vooraan staan.
 
-Dodona ignores every other file and directory. You can thus freely create additional files (for example, containing the solutions to your exercises) or create a personal exercise hierarchy. The only thing that isn't allowed is placing exercise directories inside other exercise directories.
+Dodona negeert elk ander bestand of elke andere folder. Je kan dus vrijuit andere bestanden (bijvoorbeeld met oplossingen voor je oefeningen) aanmaken of een persoonelijke oefeningenhiërarchie maken. Het enige dat niet is toegelaten is oefeningenfolders in andere oefeningenfolders plaatsen.
 
-## Example of a valid exercise directory structure
+## Voorbeeld van de structuur van een geldige oefeningfolder
 
 ```
-+-- intsum                     # short name for the exercise
-|   +-- config.json            # configuration of the exercise
++-- intsum                     # Korte naam voor de oefening
+|   +-- config.json            # Configuratie van de oefening
 |   +-- evaluation             #
-|   |   +-- intsum_test.hs     # A Haskell test file
+|   |   +-- intsum_test.hs     # Een Haskell testbestand
 |   +-- description            #
-|   |   +-- description.nl.md  # The description in dutch
-|   |   +-- description.en.md  # The description in english
+|   |   +-- description.nl.md  # De beschrijving in het Nederlands
+|   |   +-- description.en.md  # De beschrijving in het Engels
 |   |   +-- media              #
-|   |   |   +-- some_image.png # An image used in the description
+|   |   |   +-- some_image.png # Een afbeelding die gebruikt wordt in de beschrijving
 |   |   +-- boilerplate        #
-|   |       +-- boilerplate    # Default (here dutch?) boilerplate code
-|   |       +-- boilerplate.en # English boilerplate code
-|   +-- workdir                # current working dir for student code
-|       +-- intlines.txt       # a file available to the student
+|   |       +-- boilerplate    # Standaard boilerplate code
+|   |       +-- boilerplate.en # Engelse boilerplate code
+|   +-- workdir                # Huidige werkfolder voor de code van de student
+|       +-- intlines.txt       # Een bestand beschikbaar voor de student
 :
 ```
 
-## Example of a valid reading activity directory structure
+## Voorbeeld van de structuur van een geldige leesactiviteitfolder
 
 ```
-+-- Aeneid                     # Short name for the reading activity
-|   +-- config.json            # Configuration of the reading activity
-|   +-- README.md              # Description of the reading activity
++-- Aeneas                     # Korte naam voor de leesactiviteit
+|   +-- config.json            # Configuratie van de leesactiviteit
+|   +-- README.md              # Beschrijving van de leesactiviteit
 |   +-- description            #
-|   |   +-- description.nl.md  # The description in Dutch
-|   |   +-- description.en.md  # The description in English
+|   |   +-- description.nl.md  # De beschrijving in het Nederlands
+|   |   +-- description.en.md  # De beschrijving in het Engels
 |   |   +-- media              #
-|   |   |   +-- some_image.png # An image used in the description
+|   |   |   +-- some_image.png # Een afbeelding die gebruikt wordt in de beschrijving
 :
 ```

--- a/nl/references/exercise-directory-structure/README.md
+++ b/nl/references/exercise-directory-structure/README.md
@@ -1,11 +1,11 @@
 ---
-title: "Oefeningfolderstructuur"
-description: "Oefeningfolderstructuur Dodona"
+title: "Oefeningmap-structuur"
+description: "Oefeningmap-structuur Dodona"
 ---
 
-# Oefeningfolderstructuur
+# Oefeningmap-structuur
 
-Binnenin een oefeningenfolder behandelt Dodona elke folder met een `config.json`-bestand als een aparte leeractiviteit: dit kan een programmeeroefening zijn of een leesactiviteit. We verwachten dat deze folder de volgende structuur heeft: 
+Binnenin een oefeningmap behandelt Dodona elke map met een `config.json`-bestand als een aparte leeractiviteit: dit kan een programmeeroefening zijn of een leesactiviteit. We verwachten dat deze folder de volgende structuur heeft: 
 
 - **Een `config.json`-bestand**: dit bestand bevat de[oefening-specifieke configuratie](../exercise-config). Deze configuratie zal samengevoegd worden met alle `dirconfig.json`-bestanden in de bovenliggende folder van de oefeningfolder. Je kan altijd configuratiewaarden die ingesteld werden door een bovenliggende folder overschrijven. 
 - **Een optioneel `readme.md`-, `readme.en.md`- en/of `readme.nl.md`-bestand:** De inhoud van deze bestanden zal getoond worden op de oefening-infopagina.Deze bestanden hebben als doel extra informatie geven aan leerkrachten die deze oefening misschien willen gebruiken in een cursus. Als er een bestand beschikbaar is in de taal van de gebruiker (`readme.<taal>.md`), dan zal deze getoond worden in plaats van het generieke `readme.md`-bestand. Dit is nuttig omdat `readme.md` getoond wordt door GitHub in de oefeningfolder. We suggereren om een `readme.md`-bestand te maken in de taal van je doelpubliek en dit optioneeel te vertalen door `readme.nl.md` of `readme.en.md` te voorzien. Neem een kijkje in de [voorbeeldoefeningenrepository](https://github.com/dodona-edu/example-exercises) om een voorbeeld te vinden van hoe je deze bestanden gebruikt.


### PR DESCRIPTION
This PR translates 2 files that were previously only available in English to Dutch.

- [x] exercise config
- [x] exercise directory structure