### PR TITLE
Review of existing TESTed documentation

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -61,7 +61,7 @@ module.exports = {
           '/nl/news/': getNewsSidebar('nl', 'Nieuws', 'Overzicht'),
           '/nl/guides/': getGuidesSidebar('nl', 'Handleidingen', 'Overzicht', 'Voor studenten', 'Voor leerkrachten'),
           '/nl/references/': getReferencesSidebar('nl', 'Referenties', 'Overzicht'),
-          '/nl/tested/': getTESTedSidebar('nl', 'TESTed judge', 'Overzicht', 'Referenties'),
+          '/nl/tested/': getTESTedSidebar('nl', 'TESTed-judge', 'Overzicht'),
           '/nl/': getGeneralSidebar()
         }
       },
@@ -79,7 +79,7 @@ module.exports = {
           '/en/news/': getNewsSidebar('en', 'News', 'Overview'),
           '/en/guides/': getGuidesSidebar('en', 'Guides', 'Overview', 'For students', 'For teachers'),
           '/en/references/': getReferencesSidebar('en', 'References', 'Overview'),
-          '/en/tested/': getTESTedSidebar('en', 'TESTed judge', 'Overview', 'References'),
+          '/en/tested/': getTESTedSidebar('en', 'TESTed judge', 'Overview'),
           '/en/': getGeneralSidebar()
         }
       },
@@ -225,7 +225,7 @@ function getReferencesSidebar(lang, groupTitle, FirstItem) {
   ]
 }
 
-function getTESTedSidebar(lang, groupTitle, FirstItem, referenceItem) {
+function getTESTedSidebar(lang, groupTitle, FirstItem) {
   return [
     `/${lang}/news/`,
     `/${lang}/guides/`,
@@ -237,9 +237,9 @@ function getTESTedSidebar(lang, groupTitle, FirstItem, referenceItem) {
       children: [
         // These URLs should be stable, since they are published.
         ['', FirstItem],
+        'exercise-config/',
         'json/',
         'types/',
-        'exercise-config/',
         'new-programming-language/',
       ]
     }

--- a/en/tested/README.md
+++ b/en/tested/README.md
@@ -6,16 +6,16 @@ sidebarDepth: 2
 
 # TESTed: one judge to rule them all
 
-TESTed is an *educational software testing framework* (a *judge*),
-which allows testing submissions for programming exercises based on a programming-language-independent test suite.
-This means that the requirements for submissions only need to be specified once,
-while you can still automatically test submissions in different programming languages.
-TESTed can be used as a standalone tool, but is also integrated into Dodona.
+TESTed is an *educational software testing framework* (also known as a *judge*) 
+to test submissions for programming exercises using a programming-language-independent test suite.
+It allows specifying software requirements (i.e. the tests) for an exercise once,
+while submissions in different programming languages can be tested automatically.
+TESTed can be used as a standalone command line tool,
+but it's also integrated as a judge into the online learning platform [Dodona](https://dodona.ugent.be).
 
-## When do you use TESTed?
+## When to use TESTed?
 
-In which circumstances can you use TESTed to create programming exercises?
-First, TESTed must support the programming language you want to use.
+The first requirement to using TESTed is that TESTed must support your target programming language(s).
 Currently, the following languages are supported:
 
 * Bash
@@ -26,56 +26,58 @@ Currently, the following languages are supported:
 * Kotlin
 * Python
 
-Because the programming exercises are programming-language-independent,
+Because programming exercises underpinned by TESTed are independent of any programming language,
 TESTed is best suited for the following kinds of exercises:
 
-- Exercises on concepts that are found in (almost) all programming languages.
-- Exercises where the focus lies on algorithms or other high-level concepts, not on the programming language itself.
+- Exercises on generic concepts that are found in (almost) all programming languages.
+- Exercises that focus on algorithms or high-level programming concepts, not on specific syntax or constructs of programming languages.
 
-TESTed is less suitable for exercises that focus on programming-language-specific concepts.
-For example, an exercise on C pointers won't work well with TESTed.
+TESTed is less suitable for exercises that focus on syntax or concepts for a specific programming language.
+For example, exercises on C pointers won't work well with TESTed.
 
-## Getting started with TESTed
+## Getting started
 
-The section after this one is a tutorial to create an exercise using TESTed within Dodona.
-If you want to use TESTed outside of Dodona, we recommend following the [tutorial in the repository](https://github.com/dodona-edu/universal-judge).
+The next section gives a short tutorial on designing programming exercises with TESTed for use in the online learning platform Dodona.
+If you want to use TESTed outside of Dodona, we recommend following [this tutorial](https://github.com/dodona-edu/universal-judge) instead.
 
-A number of references are also available:
+A number of technical specifications are also available:
 
-- [The configuration options](exercise-config)
-- [Format of the test suites](json)
-- [List of data types for programming languages](types)
+- [Configuration options](exercise-config)
+- [Test suite format](json)
+- [Data types for programming languages](types)
 
-If you want to work on TESTed itself, the following is useful:
+Useful guides if you want to work on TESTed itself:
 
-- The [installation instructions](https://github.com/dodona-edu/universal-judge) in the repository to run TESTed locally.
-- [Guide on adding a programming language](new-programming-language).
+- The [installation instructions](https://github.com/dodona-edu/universal-judge) to run TESTed locally.
+- A [guide on adding a programming language](new-programming-language).
 
-## Creating an exercise for TESTed
+## Designing exercises for Dodona
 
 ::: tip
-In this tutorial, we assume you'll use TESTed within Dodona.
-If that is not the case, we refer you to the [tutorial in the repository](https://github.com/dodona-edu/universal-judge).
+In this short tutorial, we assume you'll use TESTed within Dodona.
+If you want to use TESTed as a standalone tool,
+we refer you to the [tutorial in the repository](https://github.com/dodona-edu/universal-judge).
 :::
+
+### System requirements
 
 To follow this tutorial, you'll need the following on your system:
 
-- `git` - to get the exercises on Dodona. You can find more information in [chapter 1 of the book *Pro Git*](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), which explains how to install Git for various operating systems (Mac, Windows, Linux).
+- `git` - to push exercises to Dodona. You can find more information in [chapter 1 of the book *Pro Git*](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), which explains how to install Git for various operating systems (Mac, Windows, Linux).
 - a text editor (like Notepad++) to create and edit text files
 
-In this tutorial, we explain how to create a simple exercise with TESTed and make the exercise available in Dodona.
-The exercise we're creating is called "write".
-The problem statement is:
+We'll explain how to create a simple programming exercise that uses TESTed to provide automated feedback,
+and how to make the exercise available on Dodona.
+The exercise is called "echo" and has the following problem statement:
 
-> Write a function `write` that writes its argument to stdout.
-> The argument of the function will always be a string.
+> Define a function `echo` that outputs its string argument to stdout.
 
-A correct submission for this exercise in a number of programming languages is:
+Here are some correct submissions for this exercise in a couple of different programming languages:
 
 :::: tabs
 ::: tab Bash
 ```bash
-function write {
+function echo {
     echo "$1"
 }
 ```
@@ -84,20 +86,20 @@ function write {
 ```c
 #include <stdio.h>
 
-void write(char* what) {
+void echo(char* what) {
     printf("%s", what);
 }
 ```
 :::
 ::: tab Haskell
 ```haskell
-write = putStrLn
+echo = putStrLn
 ```
 :::
 ::: tab Java
 ```java
 class Submission {
-    public static void write(String what) {
+    public static void echo(String what) {
         System.out.println(what);
     }
 }
@@ -105,55 +107,56 @@ class Submission {
 :::
 ::: tab JavaScript
 ```javascript
-function write(what) {
+function echo(what) {
   console.log(what);
 }
 ```
 :::
 ::: tab Kotlin
 ```kotlin
-fun write(what: String) {
+fun echo(what: String) {
     println(what)
 }
 ```
 :::
 ::: tab Python
 ```python
-def write(argument):
+def echo(argument):
     print(argument)
 ```
 :::
 ::::
 
-These are the submissions we want to test with TESTed.
+We can use those solutions as the submissions we want to test with TESTed.
 
 ### 1. Git repository
 
 Dodona uses Git repositories to manage exercises.
-Follow the guide [_Creating a new exercise repo_](/en/guides/teachers/new-exercise-repo).
-Once you have followed this guide and created the repository, you can return to this tutorial.
+Follow the guide [_Creating a new exercise repo_](/en/guides/teachers/new-exercise-repo)
+and return to this tutorial as soon as your repository has been set up.
 
 ### 2. Folder structure
 
-We need to create the correct folder structure in the repository you just created.
-Create the following folders:
+Now we need to create the correct directory structure for Dodona exercises in the repository you just created.
+Create the following directories:
 
 ```
-├── write/          # Folder for the new exercise
+├── echo/          # Directory for the new exercise
 |   ├── evaluation/
 |   └── description/
 ```
 
-This is the Dodona folder structure; more information can be found in the [reference](/en/references/exercise-directory-structure).
+This is the Dodona directory structure for exercises.
+More information can be found in [_Exercise directory structure_](/en/references/exercise-directory-structure).
 
 ### 3. Configuration options
 
-To signal to Dodona we are creating an exercise, we must add a configuration file.
-This file contains some options and metadata used by Dodona.
+To inform Dodona we are creating an exercise, we must add a configuration file to the `echo` directory.
+This configuration file contains some options and metadata used by Dodona.
 
-Create a new file `config.json` in the folder `write`, with the following content:
+Create a new file `config.json` in the `echo` directory, with the following content:
 
-```json
+```json5
 {
   "description": {
     "names": {
@@ -162,41 +165,39 @@ Create a new file `config.json` in the folder `write`, with the following conten
     }
   },
   "evaluation": {
-    "plan_name": "testsuite.json"
+    "plan_name": "tests.json"
   },
   "programming_language": "python",
   "access": "private"
 }
 ```
 
-Four things happen here:
+This configuration file specifies, in order:
 
-1. We give a name to the exercise, in Dutch and in English.
-2. We give the location of the test suite (`testsuite.json`).
-   This is always relative to the folder `write/evaluation`.
-3. We set the default programming language to Python. While TESTed supports multiple programming languages, Dodona does not support this at the moment.
-4. We indicate it is a private exercise.
+1. An exercise name in Dutch and in English.
+2. The path name of the test suite (`tests.json`) relative to the `echo/evaluation` directory.
+3. Python as the default programming language. While TESTed supports multiple programming languages, 
+   Dodona currently supports only a single programming language per exercise.
+4. Private access to the exercise.
+   We use this default since this is a tutorial, but we encourage making exercises publicly available on Dodona. 
 
-### 4. Writing the problem statement
+See [_Exercise configuration_](/en/references/exercise-config) for more details on the configuration options for Dodona exercises.
+
+### 4. Problem statement
 
 The problem statement instructs students on how to solve the exercise.
-This is again a Dodona thing; there is nothing TESTed-specific.
-More information is thus again found in the [relevant manual](/en/references/exercise-description).
-
-To make things easier, we'll use the problem statement from above and add an example.
-Create a file `write/description/description.en.md` with the following content:
+We'll use the problem statement from above and add an example.
+Create a file `echo/description/description.en.md` with the following content:
 
 ````markdown
-Write a function `write` that writes its argument to stdout.
-
-The argument of the function will always be a string.
+Define a function `echo` that outputs its string argument to stdout.
 
 ### Example in Python
 
 ```pycon
->>> write("5");
+>>> echo("5");
 "5"
->>> write("OK");
+>>> echo("OK");
 "OK"
 ```
 ````
@@ -204,27 +205,32 @@ The argument of the function will always be a string.
 As a check, the file structure should now look like this:
 
 ```
-├── write/
+├── echo/
 |   ├── config.json
 |   ├── evaluation/
 |   ├── description/
 |   |   └── description.en.md
 ```
 
-### 5. Specifying the test suite
+This is again something that is specific for Dodona and has nothing to do with TESTed.
+See [_Exercise descriptions_](/en/references/exercise-description) for more information on how to describe problem statements for Dodona exercises.
 
-This is one of the most important parts of creating an exercise: specifying the test suite.
-This test suite contains all test cases that will be executed on the submission to check if the submission is correct.
+### 5. Test suite
 
-To keep this tutorial short, we only use one test case here, but a real test suite would contain more test cases.
+Specifying a test suite is the part of creating a Dodona exercise that is specific to a particular judge,
+so we’ll adhere to the TESTed specification for test suites in this tutorial.
+A test suite contains all test cases that will be executed on the submission to check if the submission is correct.
 
-Create a new file `evaluation/testsuite.json`:
+For brevity, we will only include a single test case in our test suite.
+But a real test suite would contain many more test cases.
+Create a new file `evaluation/tests.json`:
+
 
 ```json
 {
  "tabs": [
   {
-   "name": "Write",
+   "name": "Echo",
    "runs": [
     {
      "contexts": [
@@ -233,7 +239,7 @@ Create a new file `evaluation/testsuite.json`:
         {
          "input": {
           "type": "function",
-          "name": "write",
+          "name": "echo",
           "arguments": [
            {
             "type": "text",
@@ -258,18 +264,19 @@ Create a new file `evaluation/testsuite.json`:
 }
 ```
 
-This test suite defines a few things:
+This test suite specifies that:
 
-1. We have one tab, with the name _Write_.
-2. We define one test case in that tab.
-3. The test case calls the function `write` with one argument, the string `input-1`.
-   Conceptually, this is equivalent to `write("input-1")`.
-4. We expect `input-1` on stdout.
+1. All feedback is included in a single tab called _Echo_.
+2. The tab contains feedback on a single test case.
+3. The test case calls the function `echo` with a string argument `input-1`.
+   Conceptually, this is equivalent to calling `write("input-1")` in Python.
+4. The expected behavior of the test case is that the text `input-1` is generated on stdout.
+
 
 The file structure now looks like this:
 
 ```
-├── write/
+├── echo/
 |   ├── config.json
 |   ├── evaluation/
 |   |   └── testplan.json
@@ -277,20 +284,21 @@ The file structure now looks like this:
 |   |   └── description.en.md
 ```
 
-### 6. Add exercise to Dodona
+### 6. Add to Dodona
 
-Now we must commit the changes with `git`:
+Now we commit the new exercise with the following `git` commands:
+
 
 ```bash
 $ git add .
 $ git commit -m "My first exercise"
 ```
 
-Next, we must push the changes to our repository.
+Then we must push the changes in the repository to Dodona.
 
 ```bash
 $ git push
 ```
 
-The exercise is now done.
-You should be able to use the exercise on Dodona.
+The exercise is now fully configured and available on Dodona as a private exercise,
+ready to be included in the learning path of your courses.

--- a/en/tested/README.md
+++ b/en/tested/README.md
@@ -32,7 +32,7 @@ TESTed is best suited for the following kinds of exercises:
 - Exercises on generic concepts that are found in (almost) all programming languages.
 - Exercises that focus on algorithms or high-level programming concepts, not on specific syntax or constructs of programming languages.
 
-TESTed is less suitable for exercises that focus on syntax or concepts for a specific programming language.
+TESTed is thus less suitable for exercises that focus on syntax or concepts for a specific programming language.
 For example, exercises on C pointers won't work well with TESTed.
 
 ## Getting started
@@ -42,14 +42,14 @@ If you want to use TESTed outside of Dodona, we recommend following [this tutori
 
 A number of technical specifications are also available:
 
-- [Configuration options](exercise-config)
-- [Test suite format](json)
-- [Data types for programming languages](types)
+- [Configuration options](/en/tested/exercise-config)
+- [Test suite format](/en/tested/json)
+- [Data types for programming languages](/en/tested/types)
 
 Useful guides if you want to work on TESTed itself:
 
 - The [installation instructions](https://github.com/dodona-edu/universal-judge) to run TESTed locally.
-- A [guide on adding a programming language](new-programming-language).
+- A [guide on adding a programming language](/en/tested/new-programming-language).
 
 ## Designing exercises for Dodona
 
@@ -156,12 +156,12 @@ This configuration file contains some options and metadata used by Dodona.
 
 Create a new file `config.json` in the `echo` directory, with the following content:
 
-```json5
+```json
 {
   "description": {
     "names": {
-      "en": "Write",
-      "nl": "Schrijf"
+      "en": "Echo",
+      "nl": "Echo"
     }
   },
   "evaluation": {
@@ -176,12 +176,14 @@ This configuration file specifies, in order:
 
 1. An exercise name in Dutch and in English.
 2. The path name of the test suite (`tests.json`) relative to the `echo/evaluation` directory.
-3. Python as the default programming language. While TESTed supports multiple programming languages, 
+3. Python as the default programming language.
+   While TESTed supports multiple programming languages, 
    Dodona currently supports only a single programming language per exercise.
 4. Private access to the exercise.
    We use this default since this is a tutorial, but we encourage making exercises publicly available on Dodona. 
 
 See [_Exercise configuration_](/en/references/exercise-config) for more details on the configuration options for Dodona exercises.
+The [options specific to TESTed](/en/tested/exercise-config) can also be interesting.
 
 ### 4. Problem statement
 
@@ -218,7 +220,7 @@ See [_Exercise descriptions_](/en/references/exercise-description) for more info
 ### 5. Test suite
 
 Specifying a test suite is the part of creating a Dodona exercise that is specific to a particular judge,
-so we’ll adhere to the TESTed specification for test suites in this tutorial.
+so we must adhere to the TESTed specification for test suites.
 A test suite contains all test cases that will be executed on the submission to check if the submission is correct.
 
 For brevity, we will only include a single test case in our test suite.
@@ -279,7 +281,7 @@ The file structure now looks like this:
 ├── echo/
 |   ├── config.json
 |   ├── evaluation/
-|   |   └── testplan.json
+|   |   └── tests.json
 |   ├── description/
 |   |   └── description.en.md
 ```
@@ -294,7 +296,7 @@ $ git add .
 $ git commit -m "My first exercise"
 ```
 
-Then we must push the changes in the repository to Dodona.
+Then we must push the changes in the repository to Dodona:
 
 ```bash
 $ git push

--- a/en/tested/exercise-config/README.md
+++ b/en/tested/exercise-config/README.md
@@ -1,17 +1,17 @@
 ---
 title: Exercise configuration options
-description: "Configuration options for exercises in TESTed"
+description: "Configuration options for exercises with TESTed"
 ---
 
 # Exercise configuration options
 
-In addition to the [general configuration options](../../references/exercise-config) for programming exercises in Dodona,
+In addition to the [general configuration options](/en/references/exercise-config) for programming exercises in Dodona,
 some specific options for TESTed can be used as well.
 
 ## Test suite
 
 The default location of a test suite for TESTed is a JSON file `plan.json` in the `evaluation` directory of the exercise.
-The optional `testplan` attribute in the `evaluation` block takes an alternative location as a path name relative to the evaluation directory.
+The optional `testplan` attribute in the `evaluation` block takes an alternative location as a path name relative to the `evaluation` directory.
 
 ```json
 {
@@ -21,11 +21,11 @@ The optional `testplan` attribute in the `evaluation` block takes an alternative
 }
 ```
 
-See [_Test suite format_](../json) for a detailed description of the test suite format for TESTed.
+See [_Test suite format_](/en/tested/json) for a detailed description of the test suite format for TESTed.
 
 ## General options
 
-The `evaluation` block can contain an `option` block with attributes that influence the general behaviour of TESTed.
+The `evaluation` block can contain an `option` object with attributes that influence the general behaviour of TESTed.
 We discuss each of these options below.
 
 ### `options.mode`
@@ -75,7 +75,7 @@ Here's an example that disables falling back to contextual compilation:
 
 ## Linters
 
-When [adding support for a new programming language to TESTed](../new-programming-language),
+When [adding support for a new programming language to TESTed](/en/tested/new-programming-language),
 it is also possible to configure a [linter](https://en.wikipedia.org/wiki/Lint_(software)) that TESTed will use for static code analysis when processing submission for that language.
 TESTed currently uses the following linters:
 
@@ -218,7 +218,7 @@ TESTed supports the following attributes for linting Kotlin submissions:
 - `ktlint_ruleset`: Path name of a JAR file with additional rules, relative to the `evaluation` directory of the exercise.
 - `ktlint_experimental`: Boolean value that indicates if `ktlint` should use experimental rules (`true`; default value) or not (`false`).
 
-Here's an example that configures a `ktlint` configuration file `ktlint_rules.jar`:
+Here's an example that shows some of these attributes in action:
 
 ```json
 {
@@ -264,7 +264,7 @@ Here's an example of a complete configuration file (`config.json`) for a Dodona 
 
 ```json
 {
-  "access": "private",
+  "access": "public",
   "description": {
     "names": {
       "en": "My exercise",
@@ -273,7 +273,7 @@ Here's an example of a complete configuration file (`config.json`) for a Dodona 
   },
   "evaluation": {
     "handler": "TESTed",
-    "plan_name": "plan.yaml",
+    "plan_name": "plan.json",
     "options": {
       "mode": "batch",
       "allow_fallback": true,

--- a/en/tested/json/README.md
+++ b/en/tested/json/README.md
@@ -14,8 +14,7 @@ languages.
 The TESTed test suite format is formally specified
 by [this Python module](https://github.com/dodona-edu/universal-judge/blob/master/tested/testplan.py).
 It can also generate a JSON Schema to make the validation of test suites easier.
-The [source code repository](https://github.com/dodona-edu/universal-judge/tree/master/exercise) of TESTed contains
-examples of JSON test suites and evaluators.
+The [source code repository](https://github.com/dodona-edu/universal-judge/tree/master/exercise) for TESTed contains a number of examples of test suites.
 
 The first section of this reference describes the structure of the test suite.
 A simple dot notation is used to indicate where the attribute is located in the hierarchical structure.
@@ -1378,11 +1377,10 @@ For example:
 
 ### Data types
 
-TESTed supports three different kinds of data types: [basic data types](#basic-datatypes),
-[advanced data types](#advanced-datatypes) and [variable types](#variabletype).
+TESTed supports three different kinds of data types: [basic data types](#basic-types),
+[advanced data types](#advanced-types) and [custom types](#custom-types).
 
-Also useful is the [list of data types mapped to their actual type](../types) for the different programming languages
-supported by TESTed.
+A complete list of all supported data types and their mapping to the different programming languages can be found [here](/en/tested/types).
 
 #### Basic types
 
@@ -1391,7 +1389,7 @@ integers.
 They are used as the default data type for a concept in a specific programming language,
 but each programming language can have multiple data types that map to the concept represented by a basic type.
 
-See [_Data type support in TESTed_](../types#basic-types) for a list of types.
+See [_Data type support in TESTed_](/en/tested/types#basic-types) for a list of types.
 
 #### Advanced types
 
@@ -1399,7 +1397,7 @@ Advanced types represent specific implementations of data types, like unsigned 8
 Each advanced type corresponds to at most one data type in a programming language,
 and some programming languages will not have support for specific implementations.
 
-See [_Data type support in TESTed_](../types#advanced-types) for a list of types.
+See [_Data type support in TESTed_](/en/tested/types#advanced-types) for a list of types.
 
 #### Custom types
 

--- a/en/tested/json/README.md
+++ b/en/tested/json/README.md
@@ -17,23 +17,17 @@ It can also generate a JSON Schema to make the validation of test suites easier.
 The [source code repository](https://github.com/dodona-edu/universal-judge/tree/master/exercise) for TESTed contains a number of examples of test suites.
 
 The first section of this reference describes the structure of the test suite.
-A simple dot notation is used to indicate where the attribute is located in the hierarchical structure.
+A dot notation is used to indicate where the attribute is located in the hierarchical structure.
 A star (`*`) is used to indicate a list of objects.
 For example, `plan.tabs.*.runs.*.run` can roughly be converted to json like this:
 
 ```json5
-{
- // `plan`
- tabs: [
-  // `plan.tabs`
-  {
-   // `plan.tabs.*`
-   runs: [
-    // `plan.tabs.*.runs`
-    {
-     // `plan.tabs.*.runs.*` 
-     run: "example"
-     // `plan.tabs.*.runs.*.run`
+{                   // `plan`
+ tabs: [            // `plan.tabs`
+  {                 // `plan.tabs.*`
+   runs: [          // `plan.tabs.*.runs`
+    {               // `plan.tabs.*.runs.*` 
+     run: "example" // `plan.tabs.*.runs.*.run`
     }
    ]
   }
@@ -322,7 +316,7 @@ For most output types, this is the default value, meaning you don't need to spec
 
 An IgnoredChannel object describes that no output is expected on a specific file descriptor (e.g. stdout or stderr).
 Any output generated on the file descriptor will be ignored, and is considered correct by TESTed.
-In other words, if you do not want ouput, you should use [`EmptyChannel`](#emptychannel),
+In other words, if you do not want output, you should use [`EmptyChannel`](#emptychannel),
 while if you don't care about the output, you should use `IgnoredChannel`.
 The `EmptyChannel` is represented by a string constant `ignored`.
 
@@ -1112,9 +1106,8 @@ The [data type](#data-types) of the variable.
 
 ### Expressions
 
-TESTed currently supports three different kinds of expressions: [identifiers](#identifier)
-, [function calls](#function-call) and
-[literal values](#literal-values).
+TESTed currently supports three different kinds of expressions:
+[identifiers](#identifier), [function calls](#function-call) and [literal values](#literal-values).
 
 #### Identifier
 
@@ -1410,31 +1403,3 @@ As custom types are outputted verbatim, it is difficult to use them while still 
 programming-language-independent.
 For that reason, we strongly discourage using them.
 :::
-
-The variable type must be used when you want to represent a value, that can't be represented with a TESTed datatypes.
-
-This object has two attributes: `data` and `type`.
-
-- **data**: The name of the datatype.
-- **type**: A string with constant value `custom`.
-
-```json
-"VariableType": {
-"title": "VariableType",
-"type": "object",
-"properties": {
-"data": {
-"title": "Data",
-"type": "string"
-},
-"type": {
-"title": "Type",
-"const": "custom",
-"type": "string"
-}
-},
-"required": [
-"data"
-]
-},
-```

--- a/en/tested/new-programming-language/README.md
+++ b/en/tested/new-programming-language/README.md
@@ -37,7 +37,7 @@ To follow the parts of this tutorial that focus on the C programming language,
 you also need to have a local installation of the `gcc` compiler (version 8.1 or up).
 
 ::: tip Windows users
-We recommend using the [Windows Subsystem for Linux](https://ubuntu.com/wsl) for development on Windows machines.
+We recommend using the [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/) for development on Windows machines.
 While TESTed is itself written in Python and thus platform independent,
 dependencies for programming languages are not always available on Windows for each language.
 :::
@@ -110,8 +110,8 @@ the templates. Run the utility using the following command:
 ```
 
 Note that this command will only generate stub files for a new programming language.
-It will not modify core TESTed files, so you should not forget to register the new language in TESTed at a later stage (
-see [_Registration_](#register-the-language)).
+It will not modify core TESTed files, so you should not forget to register the new language in TESTed later 
+(see [_Registration_](#register-the-language)).
 
 We will now look at the steps you need to take to add support for the C programming language to TESTed.
 We assume the generation tool was not used, so in each step we will manually create the files.
@@ -122,8 +122,8 @@ If you did use the generation tool, skip the parts where the files are created.
 Before starting to add support for C, we first look briefly into what features of C we want to support:
 what language features can we support in TESTed and what TESTed features can we support in C?
 
-Of course, we want to support as much of the TESTed features as possible. However, there are some limitations,
-especially in the data type support.
+Of course, we want to support as much of the TESTed features as possible.
+However, there are some limitations, especially in regard to data type support.
 
 ### Unsupported basic types
 
@@ -369,7 +369,7 @@ The default implementation skips the compilation step.
 :::
 
 The first parameter of the `compilation` method takes a class with some configuration options,
-including all [exercise options](../exercise-config).
+including all [exercise options](/en/tested/exercise-config).
 For example, you could allow the exercise designer to choose what C version is used by TESTed (e.g. C99 instead of C11).
 However, the current implementation of the C language module only supports C11.
 

--- a/en/tested/new-programming-language/README.md
+++ b/en/tested/new-programming-language/README.md
@@ -1,40 +1,51 @@
 ---
-title: "Adding support for a new programming language"
-description: "Adding support for a new programming language in TESTed."
+title: "Adding new programming languages"
+description: "Configuring a new programming language in TESTed"
 ---
 
-# Adding support for a new programming language to TESTed
+# Adding new programming languages
 
-In this guide, we explain in detail how to add support for a new programming language to TESTed.
-In this guide, we add support for the programming language C.
-We do also note where we do C-specific stuff,
-so it should also be usable as a guide for adding support for other languages.
+TESTed is extensible with new programming languages.
+It is designed around a common core,
+that implements the bulk of the functionality required by a software test framework in a generic way.
+This core calls an internal API whenever it needs functionality that depends on a specific programming language.
+All programming languages supported by TESTed have a language module that implements this internal API.
+
+This tutorial explains in detail how a language module can implement the internal API for a new programming language,
+essentially extending TESTed with support for the new programming language.
+We will use the C programming language as an example
+but indicate explicitly where we make configurations that are specific for the C programming language.
+As such, you can follow this tutorial to extend TESTed with support for other programming languages.
 
 Some useful links that can help you:
 
-- Existing configurations: <https://github.com/dodona-edu/universal-judge/tree/master/tested/languages>, including the configuration for C, which is what we are adding here.
+- Implementations of modules for all programming languages currently supported by TESTed, including the C module that is
+  used as an example in this tutorial: <https://github.com/dodona-edu/universal-judge/tree/master/tested/languages>.
 - Test exercises: <https://github.com/dodona-edu/universal-judge/tree/master/exercise>
 
-## TESTed locally
+## Installing and running TESTed
 
-Since language support is added to TESTed itself, you need to get the code for TESTed locally.
-We recommend following the guide in the [readme of the TESTed repository](https://github.com/dodona-edu/universal-judge#installing-tested).
+Because support for programming languages is added to TESTed itself,
+running and testing TESTed will be essential during development of language modules.
+You therefore need to install TESTed locally.
+We recommend following the instructions from
+the [README](https://github.com/dodona-edu/universal-judge#installing-tested) in the GitHub repository of TESTed.
 Note that you only need to install the Python dependencies.
-Dependencies of other languages (e.g. ghc for Haskell) are optional.
+Dependencies for other programming languages (e.g. `ghc` for Haskell) are optional.
 
-For this guide, you also need to have an installation of gcc available,
-since that is the compiler we're going to use (version 8.1 or up).
+To follow the parts of this tutorial that focus on the C programming language,
+you also need to have a local installation of the `gcc` compiler (version 8.1 or up).
 
-::: tip Window users
-We recommend using the [Windows Subsystem for Linux](https://ubuntu.com/wsl) on Linux.
-While TESTed itself is written in Python and thus platform independent,
-the dependencies of the programming languages are not always available on Windows.
+::: tip Windows users
+We recommend using the [Windows Subsystem for Linux](https://ubuntu.com/wsl) for development on Windows machines.
+While TESTed is itself written in Python and thus platform independent,
+dependencies for programming languages are not always available on Windows for each language.
 :::
 
 ### Running TESTed
 
-After cloning the repository and installing the necessary dependencies,
-the folder in which TESTed is located should look like this:
+After cloning the GitHub repository of TESTed and installing the necessary dependencies,
+the directory in which TESTed is installed should look like this:
 
 ```
 universal-judge
@@ -46,8 +57,8 @@ universal-judge
 └── run           # Used in Dodona
 ```
 
-In this guide, we assume you run the commands in the root directory of the repository.
-The main way to run TESTed is to use the following command:
+In this tutorial, we assume you run the commands in the root directory of the repository.
+Test if you can run TESTed using the following command:
 
 ```shell
 > python -m tested --help
@@ -64,91 +75,86 @@ optional arguments:
   -v, --verbose         Include verbose logs. It is recommended to also use -o in this case.
 ```
 
-This is fine when running TESTed in production,
-but for development it is annoying to always have to specify the configuration.
-Therefore, you can use the development mode, in which the configuration is hard-coded:
+The above command is how you run TESTed in production.
+For development, however, the need to always specify an exercise configuration is somewhat cumbersome.
+For that purpose, you can run TESTed in development mode which uses a hard-coded configuration:
 
 ```shell
 > python -m tested.manual
 ```
 
-This will run an exercise according to the hard-coded values in `tested/manual.py`.
-Running in this mode will put all generated files into the `workdir` folder.
-This can be very useful, e.g. to inspect the generated code.
-If `workdir` does not exist, you might need to create it.
+Running TESTed in development mode uses the hard-coded values defined in `tested/manual.py` to evaluate an exercise
+and puts all files that are generated intermediately into the `workdir` directory of TESTed.
+The latter can be very useful, for example, to inspect the test code that is generated by a language module.
+If the `workdir` directory does not exist yet, you might need to create it.
 
-## Plan of action
+## Design choices
 
-Adding support for a programming language in TESTed boils down to implementing a programming language module for that programming language.
-Implementing such a module is theoretically as easy as creating one subclass,
-but we recommend the following structure:
+Extending TESTed with support for a new programming language comes down
+to implementing the internal API in a language module for that programming language.
+In theory, implementing such a language module is nothing more than creating one subclass.
+But we recommend the following structure:
 
-1.  The configuration file,
-    which contains some options for the programming language.
-    This also includes the type configuration, which specifies the data type support.
-2.  The configuration class, which has more dynamic options, like the compilation command that should be used when evaluating a submission.
-3.  The templates, which are used to generate the necessary test code.
+1. A configuration file that contains some specific options for the programming language.
+   This also includes the type configuration, which specifies the data type support for the programming language.
+2. A configuration class that has some more dynamic options, such as the compilation command used when evaluating
+   submissions.
+3. Templates that are used to generate test code.
 
-TESTed includes a utility to generate the necessary files in the correct location.
-Based on a few questions, stubs will be generated for the configuration file, the configuration class and the templates.
+TESTed contains a utility that generates stubs for these files in the correct location.
+Based on your answers to a few questions, stubs will be generated for a configuration file, a configuration class and
+the templates. Run the utility using the following command:
 
-You can run the utility as follows:
 ```shell
 > python -m tested.generation
 ```
 
-Note that this will only generate the necessary files.
-It will not modify existing files,
-so you must not forget to do the steps in the [Registration](#register-the-language) section later.
+Note that this command will only generate stub files for a new programming language.
+It will not modify core TESTed files, so you should not forget to register the new language in TESTed at a later stage (
+see [_Registration_](#register-the-language)).
 
-We will now look at the various features of the programming language C.
-We will assume the generation tool was not used, so the files need to be created manually.
-If you did use the generation tool, skip the instructions on creating files.
+We will now look at the steps you need to take to add support for the C programming language to TESTed.
+We assume the generation tool was not used, so in each step we will manually create the files.
+If you did use the generation tool, skip the parts where the files are created.
 
-## The programming language C
+## The C programming language
 
-Before starting with adding support for C,
-we will look briefly at which features of C we want to support:
-which features of the language can we support in TESTed and which features from TESTed can we support in C?
+Before starting to add support for C, we first look briefly into what features of C we want to support:
+what language features can we support in TESTed and what TESTed features can we support in C?
 
-Of course, we want to support as much as possible.
-However, there are some limitations, specifically in the data type support.
+Of course, we want to support as much of the TESTed features as possible. However, there are some limitations,
+especially in the data type support.
 
-##### Unsupported basic types
+### Unsupported basic types
 
-In our support for C, we won't support the following basic types:
+In the C language module, we will not support the following basic types:
 
 - `sequence`:
-  Arrays are a special case in C.
-  For example, static arrays cannot be used as a return value,
-  and are not ideal as function parameter either.
-  To use dynamic arrays effectively, you need a pointer to the data and the size of the array.
-  This has implications:
-  for example, if you want to pass an array as a parameter to a function, you need to pass two parameters.
-  TESTed has no support for this at the moment.
-  As such, arrays are not supported.
-- `set`:
-  C does not have any built-in sets.
-- `map`:
-  C does not have any built-in maps.
-  There are structs, but it is not possible to get the field names at runtime, so there is no way to serialize them.
+  Arrays in C are special, compared to other programming languages.
+  Static arrays cannot be used as a return value, and are not ideal as function parameters either.
+  On the other hand, effectively using a dynamic array requires a pointer to the data and the size of the array.
+  This has implications: for example, you need to pass two parameters if you want to pass an array to a function.
+  TESTed currently has no support to pass literal values through multiple parameters,
+  so sequences are currently not supported for the C programming language.
+  Arrays as return values could be possible by using a struct that wraps the pointer and its size.
+  However, this is non-standard and thus not supported at the moment.
+- `set`: C does not have built-in sets.
+- `map`: C does not have built-in maps.
+  C has structs, but it is not possible to get access to their field names at runtime,
+  so there is no way to serialize them.
 
-##### Unsupported advanced types
+### Unsupported advanced types
 
-Of the basic types that we do support, we cannot support the following advanced types:
+Obviously, the C language module will not support any advanced type that has an unsupported basic type.
+In addition, the C language module will also not support the following advanced types:
 
-- `big_int`:
-  C does not have a type for arbitrary size numbers.
-- `fixed_precision`:
-  C does not have a type for fixed precision floats.
-- **Other data types**:
-  This concerns types such as `array` and `list`.
-  Similarly, `tuple` is also not supported.
+- `bigint`: C does not have built-in arbitrary precision integers.
+- `fixed_precision`: C does not have built-in fixed precision real numbers.
 
-The first step is to create a folder in which we will put the code of the C module.
-This folder should be named after the programming language
-and created in the correct location within the source directory.
-Create a new folder `tested/languages/c`:
+The first step is to create a directory for the configuration code of the C language module.
+This directory must be named after the programming language
+and created as a subdirectory of the `tested/languages` directory.
+Create a new directory `tested/languages/c`:
 
 ```
 universal-judge/
@@ -166,223 +172,237 @@ universal-judge/
 
 ## Configuration file
 
-The configuration file is a JSON file with some properties of the programming language.
-Technically, this file is optional: you only need to implement the configuration class (which we'll do later).
-However, using the configuration file is easier.
-Create the configuration file `tested/languages/c/config.json`:
+A configuration file for a programming language in TESTed is a JSON file
+configuring some static properties of the language.
+Technically, this file is optional: you only need to implement the configuration class,
+which we will do in [_Configuration class_](#configuration-class).
+However, using a configuration file makes the implementation of the configuration class much easier.
+Create a configuration file `tested/languages/c/config.json` (however, you probably want to remove the comments, as
+those are not support by JSON):
 
 ```json5
 {
-  // General options about the language.
-  "general": {
-    // Files which will be available in the compilation and execution step.
-    // We'll discuss these later, but these are dependencies that are needed
-    // during the compilation step in C.
-    "dependencies": [
-      "values.h",
-      "values.c",
-      "evaluation_result.h",
-      "evaluation_result.c"
-    ],
-    // If the language uses a selector during compilation.
-    // This is true for most languages, including C.  
-    "selector": true
-  },
-  "extensions": {
-    // Extension of the generated test code.  
-    "file": "c",
-    // Extensions of the templates.
-    // Defaults to the file extension and mako.
-    "templates": ["c", "mako"]  // The default value, so not really necessary.
-  },
-  // Language constructs are translated into the style of the programming language
-  "naming_conventions": {
-    // Possibilities are snake_case, camelCase and PascalCase
-    "namespace": "snake_case",
-    // snake_case is the default
-    "function": "snake_case"
-  },
-  // Indicate for which language constructs recognized by TESTed
-  // we want to add support.
-  // By default, all constructs are false, meaning no support.
-  "constructs": {
-    // Object-oriented stuff, such as classes and constructors.
-    "objects": false,
-    // Throwable exceptions.
-    "exceptions": false,
-    // Functions
-    "function_calls": true,
-    // Assignments (often a variable)
-    // However, e.g. in Haskell this is implemented as a constant function
-    // returning the same value. So, it is a "conceptual" assignment, not
-    // necessarily a real one.
-    // For example, `x = 5` is technically a function in Haskell, but is
-    // considered an assignment in TESTed.
-    "assignments": true,
-    // If collections (e.g. lists) can have elements of different types.
-    // For example, there is support in Python; it is difficult 
-    // in Java and Haskell does not support it at all.
-    "heterogeneous_collections": false,
-    // If a function can accept arguments of different types.
-    // For example, Java supports this with method overloading.
-    // On the other hand, C does not support this.
-    // An example is `echo("string")` and `echo(5)`.
-    "heterogeneous_arguments": false,
-    // If programmed checks are supported in this language.
-    // Technically, not a language construct.
-    "evaluation": false,
-    // If named function arguments are supported.
-    // This implies the arguments can be passed in a different order.
-    // For example, Python supports this.
-    "named_arguments": false,
-    // If default values for function arguments are supported.
-    "default_parameters": false
-  },
-  // Indicate which datatypes are supported in this language.
-  // By default, all basic types are supported, but advanced types are not.
-  // There are three possible values:
-  // - supported: full support
-  // - unsupported: no support
-  // - reduced: only for advanced types. This indicates that the type will
-  //   be reduced to its basic type. E.g. a list will become a sequence.
-  "datatypes": {
-    // BASIC TYPES
-    "integer": "supported",
-    "rational": "supported",
-    "char": "supported",
-    "text": "supported",
-    "boolean": "supported",
-    "sequence": "unsupported",
-    
-    // ADVANCED TYPES
-    "set": "unsupported",
-    "map": "unsupported",
-    "nothing": "supported",
-    "int8": "supported",
-    "uint8": "supported",
-    "int16": "supported",
-    "uint16": "supported",
-    "int32": "supported",
-    "uint32": "supported",
-    "int64": "supported",
-    "uint64": "supported",
-    "bigint": "reduced",
-    "single_precision": "supported",
-    "double_precision": "supported",
-    "double_extended": "supported",
-    "fixed_precision": "unsupported",
-    "array": "unsupported",
-    "list": "unsupported",
-    "tuple": "unsupported"
-  },
-  // Indicate limits on data structures.
-  // For example, some languages have limits on the possible types for keys
-  // in map-like data structures.
-  // For example, maps are implemented using Objects in JavaScript, which means
-  // that not all types are usable as keys.
-  // This is an advanced configuration. We recommend leaving it until later.
-  // For C, the list is empty, since C does not support either data structure.
-  "restrictions": {
-    "map_key": [],
-    "set": []
-  }
+ // General options about the language.
+ "general": {
+  // Files which will be available in the compilation and execution step.
+  // We'll discuss these later, but these are dependencies that are needed
+  // during the compilation step in C.
+  "dependencies": [
+   "values.h",
+   "values.c",
+   "evaluation_result.h",
+   "evaluation_result.c"
+  ],
+  // If the language uses a selector during compilation.
+  // This is true for most languages, including C.  
+  "selector": true
+ },
+ "extensions": {
+  // Extension of the generated test code.  
+  "file": "c",
+  // Extensions of the templates.
+  // Defaults to the file extension and mako.
+  "templates": [
+   "c",
+   "mako"
+  ]
+  // The default value, so not really necessary.
+ },
+ // Language constructs are translated into the style of the programming language
+ "naming_conventions": {
+  // Possibilities are snake_case, camelCase and PascalCase
+  "namespace": "snake_case",
+  // snake_case is the default
+  "function": "snake_case"
+ },
+ // Indicate for which language constructs recognized by TESTed
+ // we want to add support.
+ // By default, all constructs are false, meaning no support.
+ "constructs": {
+  // Object-oriented stuff, such as classes and constructors.
+  "objects": false,
+  // Throwable exceptions.
+  "exceptions": false,
+  // Functions
+  "function_calls": true,
+  // Assignments (often a variable)
+  // However, e.g. in Haskell this is implemented as a constant function
+  // returning the same value. So, it is a "conceptual" assignment, not
+  // necessarily a real one.
+  // For example, `x = 5` is technically a function in Haskell, but is
+  // considered an assignment in TESTed.
+  "assignments": true,
+  // If collections (e.g. lists) can have elements of different types.
+  // For example, there is support in Python; it is difficult 
+  // in Java and Haskell does not support it at all.
+  "heterogeneous_collections": false,
+  // If a function can accept arguments of different types.
+  // For example, Java supports this with method overloading.
+  // On the other hand, C does not support this.
+  // An example is `echo("string")` and `echo(5)`.
+  "heterogeneous_arguments": false,
+  // If programmed checks are supported in this language.
+  // Technically, not a language construct.
+  "evaluation": false,
+  // If named function arguments are supported.
+  // This implies the arguments can be passed in a different order.
+  // For example, Python supports this.
+  "named_arguments": false,
+  // If default values for function arguments are supported.
+  "default_parameters": false
+ },
+ // Indicate which datatypes are supported in this language.
+ // By default, all basic types are supported, but advanced types are not.
+ // There are three possible values:
+ // - supported: full support
+ // - unsupported: no support
+ // - reduced: only for advanced types. This indicates that the type will
+ //   be reduced to its basic type. E.g. a list will become a sequence.
+ "datatypes": {
+  // BASIC TYPES
+  "integer": "supported",
+  "rational": "supported",
+  "char": "supported",
+  "text": "supported",
+  "boolean": "supported",
+  "sequence": "unsupported",
+  // ADVANCED TYPES
+  "set": "unsupported",
+  "map": "unsupported",
+  "nothing": "supported",
+  "int8": "supported",
+  "uint8": "supported",
+  "int16": "supported",
+  "uint16": "supported",
+  "int32": "supported",
+  "uint32": "supported",
+  "int64": "supported",
+  "uint64": "supported",
+  "bigint": "unsupported",
+  "single_precision": "supported",
+  "double_precision": "supported",
+  "double_extended": "supported",
+  "fixed_precision": "unsupported",
+  "array": "unsupported",
+  "list": "unsupported",
+  "tuple": "unsupported"
+ },
+ // Indicate limits on data structures.
+ // For example, some languages have limits on the possible types for keys
+ // in map-like data structures.
+ // For example, maps are implemented using Objects in JavaScript, which means
+ // that not all types are usable as keys.
+ // This is an advanced configuration. We recommend leaving it until later.
+ // For C, the list is empty, since C does not support either data structure.
+ "restrictions": {
+  "map_key": [],
+  "set": []
+ }
 }
 ```
 
-## User-facing type configuration
+## Language-specific names for data types
 
 ::: warning Experimental
-This file is currently experimental, and thus optional.
+Currently,
+configuration of language-specific names for data types is an experimental feature of TESTed and thus optional.
 :::
 
-When generating problem statements,
-TESTed needs to know how certain data types should be shown to the user.
-For this purpose, you can provide a type configuration file.
-Create the configuration file `tested/languages/c/types.json`.
-See the existing files for examples.
-Note that this is experimental, so changes are possible.
+TESTed supports describing problem statements in a generic way,
+using a templating system
+in which placeholders will be replaced by text that depends on a specific programming language.
+One aspect of this process is
+that the same data type might be known under different names in different programming languages.
+For this purpose, create a type configuration file `tested/languages/c/types.json`.
+See the different files for the different programming languages for examples.
+Note that this feature of TESTed is still experimental, so future changes are possible.
 
 ## Configuration class
 
-The configuration class is the only mandatory part of adding language support.
-It serves as the API between TESTed and the language module.
-Because TESTed is written in Python, the class needs to be Python as well.
+A configuration class is the only mandatory part of extending TESTed with support for a programming language.
+It implements the internal API that TESTed uses as an interface between the core module and a language module.
+Because the core module of TESTed is implemented in Python,
+a configuration class needs to be implemented in Python as well.
 
-Create a file `tested/languages/c/config.py` and add a class the inherits from `Language`:
+Create a Python module `tested/languages/c/config.py` and define a class that inherits from `Language`:
 
 ```python
 class C(Language):
-  # See the docs of the parent class for all available options.
-  # Most of the default implementations fall back to using the JSON
-  # configuration file, but you could also override them all and not
-  # use the configuration file.
+    # See the docs of the parent class for all available options.
+    # Most of the default implementations fall back to using the JSON
+    # configuration file, but you could also override them all and not
+    # use the configuration file.
 
-  # The compilation command used by TESTed.
-  # See below for more information, or check the method documentation
-  # for technical details.
-  def compilation(self, config: Config, files: List[str]) -> CallbackResult:
-    main_file = files[-1]
-    exec_file = Path(main_file).stem
-    result = executable_name(exec_file)
-    return (["gcc", "-std=c11", "-Wall", "evaluation_result.c", "values.c",
-             main_file, "-o", result], [result])
+    # The compilation command used by TESTed.
+    # See below for more information, or check the method documentation
+    # for technical details.
+    def compilation(self, config: Config, files: List[str]) -> CallbackResult:
+        main_file = files[-1]
+        exec_file = Path(main_file).stem
+        result = executable_name(exec_file)
+        return (["gcc", "-std=c11", "-Wall", "evaluation_result.c", "values.c",
+                 main_file, "-o", result], [result])
 
-  # Execution command used by TESTed.
-  # This will execute the result of the compilation command.
-  # See below for more information, or check the method documentation
-  # for technical details.
-  def execution(self, config: Config,
-                cwd: Path, file: str, arguments: List[str]) -> Command:
-    local_file = cwd / executable_name(Path(file).stem)
-    return [str(local_file.absolute()), *arguments]
+    # Execution command used by TESTed.
+    # This will execute the result of the compilation command.
+    # See below for more information, or check the method documentation
+    # for technical details.
+    def execution(self, config: Config,
+                  cwd: Path, file: str, arguments: List[str]) -> Command:
+        local_file = cwd / executable_name(Path(file).stem)
+        return [str(local_file.absolute()), *arguments]
 
-
-  def solution(self, solution: Path, bundle: Bundle):
-    # Contains some code to change the main function.
-    # See the actual implementation for the details.
-    pass
+    def solution(self, solution: Path, bundle: Bundle):
+        # Contains some code to change the main function.
+        # See the actual implementation for the details.
+        pass
 ```
 
-### Compilation step
+### Compilation
 
 ::: tip Interpreted languages
-Whenever possible, we recommend adding a compilation step, even if the language is not compiled.
-For example, in Python and JavaScript the compilation step is used to check the syntax of the submission.
-However, if the language does not support it (e.g. Bash),
-you can skip this implementation; the default implementation does nothing.
+Whenever possible, we recommend adding a compilation step even for languages that are interpreted and not compiled.
+For example, the compilation steps for Python and JavaScript check that submissions have no syntax errors.
+However, if the programming language does not support relevant static code analysis prior to execution (e.g. Bash),
+you can skip this part of the configuration class.
+The default implementation skips the compilation step.
 :::
 
-The first parameter in the `compilation` method is a class with some configuration options.
-These options include all exercise options.
-For example, you could enable the exercise author to choose the C version used by TESTed (e.g. C99 instead of C11).
-However, in this case, we only support C11.
+The first parameter of the `compilation` method takes a class with some configuration options,
+including all [exercise options](../exercise-config).
+For example, you could allow the exercise designer to choose what C version is used by TESTed (e.g. C99 instead of C11).
+However, the current implementation of the C language module only supports C11.
 
-The second parameter is a list of files TESTed considers to be useful to have during compilation.
-It will contain the dependencies specified by the configuration file, the submission and the generated test code files.
-By convention, the last file in the list is the one with the main function, and should thus be the one being compiled.
+The second parameter of the `compilation` method takes a list of files that TESTed deems useful to have during
+compilation,
+including all dependencies specified in the configuration file,
+the submission and files containing the generated test code.
+By convention, the last file in the list contains the `main` function and should thus be the file being compiled.
+All files will be in the same directory as the main file.
+The compilation method does not need to use all files.
+In case of the C programming language, for example, `gcc` takes care of loading all other files,
+so we only use the main file.
+As is done in the C language module,
+you can also hardcode the names of files defined as dependencies in the configuration file.
 
-All of these files will be in the same directory as the main file.
-It's not mandatory to actually use the files, e.g. for C,
-GCC will take care of loading all other files, so we only use the main file.
-As we do, you can also hardcode the name of files defined as a dependency in the configuration file.
+The compilation method must return a tuple with two elements: i) the compilation command and ii) the resulting files or
+file filter.
+TESTed uses the Python module `subprocess` to execute the compilation command.
+The resulting list of files or file filter is used to copy the compiled executable to the execution directory.
+Only the compiled executable will be available during execution.
 
-The method must be a tuple with two elements: the compilation command and the resulting file or file filter.
+You can return a list of files if the compilation process results in executable files with predictable names.
+For example, in C we know the name of the resulting binary, so we just return a list containing that name.
+When returning a list of files, you should also follow the convention that the main file is at the end of the list.
 
-The compilation command will be executed by TESTed with the `subprocess` Python module.
-
-The resulting file or file filter is used to copy the compiled binary to the execution directory.
-Only this file will be available during execution.
-You can return a list of files if the result of compilation is a file with a predicable name.
-For example, in C we always know the name of the binary, so we just return that.
-When returning a list, you should also place the "main" file at the end.
-
-However, this is not always the case.
-For example, compiling a `.java` file will result in one or more `.class` files,
+However, it is not always possible to predict the list of executables.
+In Java, for example, compiling a `.java` file will result in one or more `.class` files,
 depending on the content of the `.java` file.
-Therefore, you can return a filter function, which determines which files are kept.
-TESTed will call the filter function for each file in the compilation directory after compiling.
+In that case, you can return a filter function that determines what executable files must be copied.
+After compilation, TESTed will call the filter function for each file in the compilation directory.
 
-An example of calling this method with the parameters and return values for C:
+Here's an example of calling the compilation method with the arguments and return values for C (on Windows):
+
 ```python
 >>> compilation(['submission.c', 'evaluation_result.c', 'context_0_0.c', 'selector.c'])
 (
@@ -391,75 +411,84 @@ An example of calling this method with the parameters and return values for C:
 )
 ```
 
-Return an empty compilation command to skip compilation.
+Return an empty list as the compilation command to skip compilation.
 
 ### Execution
 
-After compiling the submission and test code, the test code must be executed to get the results of the evaluation.
-This method has four parameters:
+After compiling the submission and the test code,
+TESTed must execute the test code to get the results that must be evaluated.
+This is done by calling the `execution` method, which has four parameters:
 
-- `config`:
-  Same as for the compilation method.
-  For example, the Java implementation uses this to set the maximum JVM memory.
-- `cwd`:
-  the directory in which the execution is taking place
-- `file`:
-  the executable file that must be executed
-- `arguments`:
-  arguments that should be passed to the process.
-  This is used, for example, to select which context should be executed.
+- `config`: Same purpose as the first parameter of the `compilation` method.
+  For example, the Java implementation uses this parameter to set the maximum JVM memory.
+- `cwd`: Path name of the directory in which execution is taking place.
+- `file`: Name of the file that must be executed.
+- `arguments`: Arguments passed to the execution process. These are used, for example, to select what context TESTed must execute.
 
-The return value is again a command that will be passed to the `subprocess` module.
+The `execution` method must return the execution command.
+TESTed again uses the Python module `subprocess` to execute the execution command.
+For the C programming language, TESTed simply executes the executable file with the given arguments. Here's an example of calling the execution method with the arguments and return values for C (on Windows):
 
-In the case of C, this is simple: we execute the executable file and pass the arguments to it.
 
-An example is:
 ```python
 >>> execution('/test/path', 'executable.exe', ['arg1', 'arg2'])
 ['/test/path/executable.exe', 'arg1', 'arg2']
 ```
 
-In most languages, we are done by now with the configuration.
-However, a C program can only have one main function.
-Since the submission can have a main function, and the generated test code also has a main function, there is a conflict.
-As such, we use the `submission` method to modify the submission by renaming the main function.
+For most languages, this ends the configuration process.
+However, the C programming language has the restriction that executables can only have a single `main` function.
+This gives a possible conflict because the submission can have a `main` function and the generated test code also has a `main` function.
+To resolve this conflict, we can use the submission method to modify the code of the submission by renaming the main function.
+See the [actual implementation](https://github.com/dodona-edu/universal-judge/blob/2cd131a5f34de93d6a68d4234fb0b595f28285d9/tested/languages/c/config.py#L87) on GitHub.
 
 ## Templates
 
-Finally, we need to implement a set of templates that will be used by TESTed to generate the test code
-(and translate the test suite into the programming language of the submission).
+As a last step, we need to implement some templates TESTed will use to generate test code and to translate the test suite into the programming language of the submission.
 
-Some templates are mandatory (as they are used by the configuration class),
-but it is often useful to create a few more templates, to enable reuse.
-For C, we create the following templates:
+Some templates are somewhat mandatory because they are used by the default implementation of the configuration class,
+but it is often useful to create a few more templates to enable reuse.
+For the C language module, we create the following templates:
 
-- `run.c`: template for a run, used to execute multiple contexts (**mandatory**)
-- `selector.c`: template to select which context to run when using batch compilation (**mandatory** if batch compilation is supported)
+- `run.c`: template to execute multiple contexts together (**mandatory**)
+- `selector.c`: template to select what context to execute when using batch compilation (mandatory if batch compilation is supported) (**mandatory** if batch compilation is supported)
 - `declaration.mako`: translates a variable declaration to C
 - `function.mako`: translates a function call to C
-- `statement.mako`: translates a TESTed statement (thus also expressions) to C (**mandatory**)
-- `value.mako`: translates a literal to C (we also have a two helper templates: `value_arguments.mako`, `value_basic.mako`)
+- `statement.mako`: translates a TESTed statement (including expressions) to C (**mandatory**)
+- `value.mako`: translates a literal value to C; makes use of two helper templates: `value_arguments.mako` and `value_basic.mako`
 
 All templates are located in `tested/languages/c/templates`.
 
 ### Run template
 
-This is conceptually the most complex template.
-It is responsible for generating the test code for one run.
+The run template is conceptually the most complex template.
+It is responsible for generating the test code for a single run.
 
 ::: tip Runs in TESTed
-Normally, TESTed will execute every context separately.
-However, this means starting a new process for each context, which can introduce a lot of overhead.
-As such, TESTed will combine contexts into one run, which is then run in a single process.
+Conceptually, TESTed will execute test code for each individual context to make sure that contexts are evaluated in isolation.
+However, this means launching a new execution process for each individual context, which may introduce a lot of overhead.
+As such, TESTed may combine multiple contexts in a single run, essentially executing all these contexts in a single process.
+In that case, care should be taken that successive contexts do not interfere with each other.
 :::
 
-::: tip Mako white space
-TESTed uses the templating system Mako for these templates.
-The default configuration in TESTed will strip Mako-induced white space.
-For example, the `for`-loop above will not be intended in the final file.
+::: tip White space in Mako
+TESTed uses the Mako templating system for its templates.
+The default configuration of Mako in TESTed will strip Mako-induced white space.
+For example, the `for`-loop below will not be indented in the test code:
 
-Newlines in the template will result in newlines in the final file.
-This can be prevented by using a backslash:
+```c
+% for name in evaluator_names:
+    #include "${name}.c"
+% endfor
+```
+
+Will result in 
+
+```c
+#include "name1.c"
+```
+
+Newlines in a template file will result in newlines in the test code.
+This can be suppressed by using a backslash to escape the newline:
 
 ```c
 int test = \⏎
@@ -467,17 +496,20 @@ int test = \⏎
 ```
 
 Will result in:
+
 ```c
 int test = "test";⏎
 ```
+
 :::
 
-In C, the annotated implementation is:
+Here's the annotated implementation of the run template in the C language module:
+
 
 ```c
 #include <stdio.h>
 
-// Include the values module, reponsible for serialisation.
+// Include the values module, responsible for serialisation.
 #include "values.h"
 // Include the submission code.
 #include "${submission_name}.c"
@@ -490,9 +522,9 @@ In C, the annotated implementation is:
 // Create the variables which will contain the names of the files used to
 // save the return values and the exceptions.
 // C doesn't support exceptions, but TESTed still requires the file to be present.
-// We also define two functions to write a seperator to the file.
+// We also define two functions to write a separator to the file.
 // These will be used between each context and each test case,
-// allowing TESTed to seperate the results in the output files.
+// allowing TESTed to separate the results in the output files.
 static FILE* ${execution_name}_value_file = NULL;
 static FILE* ${execution_name}_exception_file = NULL;
 
@@ -510,25 +542,24 @@ static void ${execution_name}_write_context_separator() {
     fprintf(stderr, "--${context_secret_id}-- SEP");
 }
 
-... continued after the text block
+// ... continues in the next code block
 ```
 
-If a return value is produced, it must be serialized before it is written to the output file.
-This serialization converts the programming-language-specific value into the language-independent format used by TESTed.
-It is useful to implement this as a separate module, which is called "values" by convention.
+If a function or method call returns a value, TESTed must serialize the value before writing it to an output file.
+This serialization converts the representation of the value in a programming language into the language-independent format used by TESTed.
+It is useful to implement data serialization as a separate module, which is called "values" by convention.
+TESTed expects an implementation of the following functions:
 
-TESTed will expect the following functions to be available:
+- `send_value(value)`: Serializes and writes a value to the return output file.
+- `send_exception(exception)`: Serializes and writes an exception to the exception output file.
+- `send_specific_value(value)`: Serializes and writes the result of a check for a specific programming language to the return channel.
+- `send_specific_exception(exception)`: Serializes and writes the result of a check for a specific programming language to the exception channel.
 
-- `send_value(value)` serialise and write a value to the return output file.
-- `send_exception(exception)` serialise and write an exception to the exception file.
-- `send_specific_value(value)` serialise and write the result of a programming-language-specific check for the return channel.
-- `send_specific_exception(exception)` serialise and write the result of a programming-language-specific check for the exception channel.
+As the C programming language does not support exceptions, we implement the two exception functions. The two return functions are implemented using a macro:
 
-However, since C does not support exceptions, we don't implement those.
-The other functions are implemented using a macro:
 
 ```c
-... continued from before the text block
+// ... continuation of the previous code block
 
 // Uses the function from the values module.
 #undef send_value
@@ -537,14 +568,13 @@ The other functions are implemented using a macro:
 #undef send_specific_value
 #define send_specific_value(value) write_evaluated(${execution_name}_value_file, value)
 
-... continued after the text block
+// ... continues in the next code block
 ```
 
-Finally, we execute the contexts.
-We generate a function per context:
+Finally, we execute the contexts by generating test code that defines one function per context:
 
 ```c
-... continued from before the text block
+// ... continuation of the previous code block
 
 // Generate a function for each context in this run:
 % for i, ctx in enumerate(contexts):
@@ -565,7 +595,7 @@ We generate a function per context:
 
 ... continued after the text block
 ```
-Now, we must still generate the code that will call these context functions:
+Now, we must still generate the test code that will call these context functions:
 
 ```c
 // Generate a function that will execute the run.
@@ -575,8 +605,8 @@ int ${execution_name}() {
     ${execution_name}_value_file = fopen("${value_file}", "w");
     ${execution_name}_exception_file = fopen("${exception_file}", "w");
 
-    // Similary to the separator for test cases, we write the context
-    // seperator between each execution of a context.
+    // Similarly to the separator for test cases, we write the context
+    // separator between each execution of a context.
     ${execution_name}_write_context_separator();
     
     // This is a special test case: it is used when you want to test
@@ -607,7 +637,7 @@ int ${execution_name}() {
     return 0;
 }
 
-// TESTed also supportes batch compilation, in which case
+// TESTed also supports batch compilation, in which case
 // we don't need a main function. Otherwise we do.
 // In batch compilation the main is not needed, since this
 // module will be called from the selector module.
@@ -620,9 +650,8 @@ int main() {
 
 ### Selector template
 
-In batch compilation, TESTed will use a selector template to choose which context is executed.
-We set `INCLUDED` to `true`, since this will allow us to include the run file from before:
-
+In batch compilation, TESTed uses the selector template to select what context is executed.
+We set `INCLUDED` to `true`, as this will allow us to include the above run template:
 
 ```c
 #include <string.h>
@@ -659,8 +688,8 @@ int main(int argc, const char* argv[]) {
 
 ### Statement template
 
-Used to convert a TESTed statement to the programming language of the submission.
-In this case, we generate C code:
+TESTed uses the statement template to convert statements and expressions to the programming language of the submission.
+This is how the C language module implements the statement template:
 
 ```c
 ## Convert a statement and/or expression into Java code.
@@ -685,39 +714,39 @@ In this case, we generate C code:
 % endif
 ```
 
-One non-intuitive aspect is the `full` parameter.
-It indicates if a variable declaration is needed or not:
+One non-intuitive aspect is the parameter `full` that indicates whether a variable declaration is needed:
 
 ```c
 int variabele = 5; // with declaration
 variabele = 6; // without declaration
 ```
 
-See the actual templates for examples of how to handle most constructs.
+See the actual templates for examples of how to handle most language constructs.
 
 ## Register the language
 
-We must also register the language module in TESTed.
-You must always do this, even if you used the generator to generate the stubs.
+We also need to register the language module in TESTed.
+This must always be done manually, even if the generator is used to generate stubs.
+In the file `tested/languages/__init__.py`, add the language to the dictionary `LANGUAGES`:
 
-In the file `tested/languages/__init__.py`, modify `LANGUAGES`:
 ```python
 LANGUAGES = {
-  'c': C,   # This is what we added here, mapping a name to the configuration class.
-  'haskell': Haskell,
-  'java': Java,
-  'javascript': JavaScript,
-  'kotlin': Kotlin,
-  'python': Python,
-  'runhaskell': RunHaskell,
+    'c': C,  # This is what we added here, mapping a name to the configuration class.
+    'haskell': Haskell,
+    'java': Java,
+    'javascript': JavaScript,
+    'kotlin': Kotlin,
+    'python': Python,
+    'runhaskell': RunHaskell,
 }
 ```
 
 ## Testing the language implementation
 
-To test the language implementation, there is a set of tests.
-You should also add support for your new programming language:
+Now that we have configured and registered the language for TESTed,
+we can test if the language implementation works as expected.
+TESTed contains some predefined tests that can be used for that purpose.
+Before this can be done, you should also extend the tests to support testing the new programming language:
 
-1. Add solutions in your programming language to one or more of the test exercises (in the folder `exercise`).
-  See the existing solutions for what your solution should do.
-2. Modify `tests/test_functionality.py` and other test files to also test the new programming language.
+1. Add solutions in the programming language to one or more of the test exercises (in the `exercise` directory). Take a look at the existing solutions to infer what your solutions should do.
+2. Modify `tests/test_functionality.py` and other test files to include the new programming language for testing.

--- a/en/tested/types/README.md
+++ b/en/tested/types/README.md
@@ -2,19 +2,39 @@
 title: Data type support
 description: "The various data types supported by TESTed"
 ---
+# Data type support
 
-# Data type support in TESTed
+This reference gives an overview of all TESTed data types (basic and advanced)
+and how they map to the data types in the programming languages that are currently supported by TESTed.
 
 ::: tip Up-to-date information
-These data are sourced from the language modules in TESTed.
-They contain the most up-to-date information on data type support.
+The mapping between TESTed data types and their mapping to the different programming languages is automatically sourced from the language modules of TESTed.
+As such, this reference should contain the most up-to-date information on data type support.
 :::
-
-This reference lists which types are used in the various programming languages and how they map to the TESTed data types.
 
 ## Basic types
 
-In the first column, we list the TESTed data type, followed by a column for each programming language.
+Basic types represent abstract data types such as integers,
+not specific implementations thereof like unsigned 8-bit integers.
+They are used as the default data type for a concept in a specific programming language,
+but each programming language can have multiple data types that map to the concept represented by a basic type.
+
+TESTed supports the following basic types:
+
+Numeric:
+- `integer`: an integer
+- `real`: a real number
+- `boolean`: a Boolean value
+- `text`: textual data (e.g. strings)
+- `sequence`: an ordered sequence of values
+- `set`: an unordered collection of unique values
+- `map`: a collection of key-value pairs
+- `nothing`: a representation of "nothing", meaning no value
+- `any`: any data type. **Note**: You cannot use this type in test suites. It is only used to indicate unknown types of return values.
+
+The following table gives an overview of basic types supported by TESTed.
+The first column contains all basic types,
+and the other columns contain the mapping to the data types of the programming languages currently supported by TESTed.
 
 | TESTed   | Python  | JavaScript | Java          | Kotlin    | Haskell   | C        | Bash   |
 |----------|---------|------------|---------------|-----------|-----------|----------|--------|
@@ -32,8 +52,36 @@ In the first column, we list the TESTed data type, followed by a column for each
 
 ## Advanced types
 
-The first column shows the name of the advanced type (below the table are some definitions of these types).
-The second column indicates what the basic type is of the advanced type.
+Advanced types represent specific implementations of data types, like unsigned 8-bit integers.
+Each advanced type corresponds to at most one data type in a programming language,
+and some programming languages will not have support for specific implementations.
+
+Currently, the following types are supported by TESTed:
+
+- `int8`: 8-bit integers (signed)
+- `uint8`: 8-bit natural numbers (unsigned)
+- `int16`: 16-bit integers (signed)
+- `uint16`: 16-bit natural numbers (unsigned)
+- `int32`: 32-bit integers (signed)
+- `uint32`: 32-bit natural numbers (unsigned)
+- `int64`: 64-bit integers (signed)
+- `uint64`: 64-bit natural numbers (unsigned)
+- `bigint`: integers without upper and lower limit (signed)
+- `single_precision` - IEEE 754 single precision real number
+- `double_precision` - IEEE 754 double precision real number
+- `double_extended` - IEEE 754 double extended precision real number
+- `fixed_precision` - fixed precision real number
+- `array`: a mutable fixed-size sequence
+- `list`: a mutable variable-size sequence
+- `tuple`: an immutable sequence
+- `char`: a single character
+- `undefined`: used for languages that make a distinction between `null` (with basic type nothing) and `undefined`, as in JavaScript
+
+The following table gives an overview of advanced types supported by TESTed.
+The first column contains all advanced types,
+and the second column contains their corresponding basic type.
+The other columns contain the mapping to the data types of the programming languages currently supported by TESTed.
+An explanation of the symbols used in the table follows after the table itself.
 
 | TESTed           | Basic    | Python    | JavaScript  | Java         | Kotlin       | Haskell            | C                | Bash |
 |------------------|----------|-----------|-------------|--------------|--------------|--------------------|------------------|------|
@@ -59,27 +107,14 @@ The second column indicates what the basic type is of the advanced type.
 ¹ built-in tuple type  
 ² built-in list type
 
-A "+" (plus sign) indicates that the programming language has limited supported (`reduced`).
-This often means there is no distinct type available in the language, but exercises using this type can still be solved in that language.
-An example is tuples: multiple languages have no tuple type, but exercises using tuples can still be solved by using the basic type (`sequence`).
-For example, an exercise using tuples will be solvable in Java by using a list.
+A plus sign (+) indicates that the programming language has **limited support** (`reduced`) for the data type.
+This often means that the programming language does not support a separate data type,
+but exercises using this type can still be solved in that language by using the basic type as a fallback.
+Let's use tuples as an example.
+Many programming languages do not have direct support for tuples,
+but exercises using tuples can still be solved by using the corresponding basic type (sequence).
+For example, an exercise using a `tuple` can be solved in Java by using a `List`.
 
-A "-" (minus sign) means that the programming language has no support (`unsupported`).
-This means exercises using those types will not be solvable in the programming language.
-For example, JavaScript does not support `fixed precision`,
-meaning exercises using this type will not be solvable in JavaScript.
-
-Below are some definitions of the types:
-
-- `intN` - signed integers, at least `N` bits; e.g. `int16` must have at least 16 bits
-- `uintN` - unsigned integers, at least `N` bits
-- `bigint` - arbitrary precision integers
-- `single_precision` - IEEE 754 single precision real number
-- `double_precision` - IEEE 754 double precision real number
-- `double_extended` - IEEE 754 double extended precision real number
-- `fixed_precision` - fixed precision real number
-- `array` - continuous piece of memory for elements of a fixed size. The difference with list is best explained in Java.
-- `list` - ordered sequence of elements, where duplicates are allowed
-- `tuple` - read-only, immutable list
-- `char` - a single character
-- `undefined` - separate from null, as in JavaScript
+A minus sign (-) means that the programming language has **no support** (`unsupported`) for the data type.
+This means that exercises using a data type that is not supported in a programming language, can not be solved in that language.
+For example, exercises using a fixed precision type can not be solved in JavaScript that does not support this data type.

--- a/en/tested/types/README.md
+++ b/en/tested/types/README.md
@@ -7,21 +7,15 @@ description: "The various data types supported by TESTed"
 This reference gives an overview of all TESTed data types (basic and advanced)
 and how they map to the data types in the programming languages that are currently supported by TESTed.
 
-::: tip Up-to-date information
-The mapping between TESTed data types and their mapping to the different programming languages is automatically sourced from the language modules of TESTed.
-As such, this reference should contain the most up-to-date information on data type support.
-:::
-
 ## Basic types
 
 Basic types represent abstract data types such as integers,
 not specific implementations thereof like unsigned 8-bit integers.
 They are used as the default data type for a concept in a specific programming language,
-but each programming language can have multiple data types that map to the concept represented by a basic type.
+but each programming language can have multiple data types for one basic type.
 
 TESTed supports the following basic types:
 
-Numeric:
 - `integer`: an integer
 - `real`: a real number
 - `boolean`: a Boolean value

--- a/nl/tested/README.md
+++ b/nl/tested/README.md
@@ -6,15 +6,14 @@ sidebarDepth: 2
 
 # TESTed: one judge to rule them all
 
-TESTed is een *educational software testing framework* (een *judge*) dat toelaat om oplossingen van een programmeeroefening te testen op basis van een programmeertaalonafhankelijk testplan.
-Dat betekent dat je de vereisten waaraan oplossingen voor de oefening moeten voldoen slechts één keer moet vastleggen,
-terwijl je toch oplossingen in verschillende programmeertalen automatisch kunt laten controleren.
-TESTed kan als afzonderlijke tool gebruikt worden, maar integreert ook met de elektronische leeromgeving Dodona.
+TESTed is een *educational software testing framework* (ook bekend als een *judge*) dat toelaat om oplossingen voor programmeeroefeningen te beoordelen op basis van een programmeertaalonafhankelijk testplan.
+Het laat om de softwarevereisten (d.w.z. de testen) voor een oefening één keer op te stellen, terwijl oplossingen in verschillende programmeertalen beoordeeld kunnen worden.
+TESTed kan als afzonderlijk tool gebruikt worden, maar is ook geïntegreerd in de elektronische leeromgeving [Dodona](https://dodona.ugent.be).
 
 ## Wanneer gebruik je TESTed?
 
-In welke omstandigheden kan je TESTed gebruiken om programmeeroefeningen aan te bieden?
-In de eerste plaats moet TESTed de programmeertaal die je wilt gebruiken ondersteunen.
+In de eerste plaats moet TESTed de programmeertaal die u wilt gebruiken ondersteunen.
+Moment
 Momenteel zijn dat volgende programmeertalen:
 
 * Bash
@@ -25,56 +24,55 @@ Momenteel zijn dat volgende programmeertalen:
 * Kotlin
 * Python
 
-Doordat de programmeeroefeningen in TESTed programmeertaalonafhankelijk zijn, is TESTed het best geschikt voor volgende soorten oefeningen:
+Doordat de programmeeroefeningen die beoordeeld worden met TESTed programmeertaalonafhankelijk zijn, is TESTed het best geschikt voor volgende soorten oefeningen:
 
-- Oefeningen die vooral concepten bevatten die in (bijna) elke programmeertaal terug te vinden zijn.
-- Oefeningen waarbij de nadruk ligt op het implementeren van algoritmen of andere concepten, en minder op de programmeertaal zelf.
+- Oefeningen op generieke concepten die in (bijna) alle programmeertalen voorkomen.
+- Oefeningen waarbij de nadruk ligt op algoritmen of programmeerconcepten op hoog niveau, niet op specifieke syntaxis of constructies van bepaalde programmeertalen.
 
-TESTed is minder geschikt voor oefeningen met een focus op programmeertaalspecifieke concepten.
-Zo zal een oefening over pointers in C niet werken in TESTed.
+TESTed is dus minder geschikt voor oefeningen met een focus op programmeertaalspecifieke concepten of syntaxis.
+Zo zal een oefening over pointers in C niet goed werken met TESTed.
 
-## Van start met TESTed
+## Van start gaan
 
-In de paragraaf hieronder volgt een tutorial om zelf een oefening op te stellen met TESTed binnen Dodona.
-Als je TESTEd wilt gebruiken buiten Dodona volg je best de [tutorial in de repository](https://github.com/dodona-edu/universal-judge).
+De volgende paragraaf is een korte handleiding over het zelf opstellen van een oefening met TESTed voor gebruik binnen Dodona.
+Als u TESTed wenst te gebruiken buiten Dodona, raden we aan [deze handleiding](https://github.com/dodona-edu/universal-judge) te volgen.
 
-Ook nuttig zijn een aantal referentiegidsen:
+Een aantal technische specificaties zijn ook beschikbaar:
 
-- [De configuratie-opties](exercise-config)
-- [Formaat van geavanceerde testplannen](/en/tested/json) (Engels)
-- [Lijst van gegevenstypes in de verschillende talen](types)
+- [Configuratie-opties](/nl/tested/exercise-config)
+- [Formaat voor testplannen](/nl/tested/json)
+- [Gegevenstypes voor programmeertalen](/nl/tested/types)
 
-Wil je aan TESTed zelf werken?
-Dan zijn volgende zaken interessant:
+Nuttige handleidingen als u aan TESTed zelf wilt werken:
 
-- De [installatie-instructies](https://github.com/dodona-edu/universal-judge) in de repo om TESTed lokaal uit te voeren.
-- [Handleiding voor het toevoegen van een programmeertaal](/en/tested/new-programming-language) (enkel in het Engels).
+- De [installatie-instructies](https://github.com/dodona-edu/universal-judge) in om TESTed lokaal uit te voeren.
+- Een [handleiding over het toevoegen van een programmeertaal](/en/tested/new-programming-language) (enkel in het Engels).
 
-## Oefeningen opstellen voor TESTed
+## Oefeningen ontwerpen voor Dodona
 
 ::: tip
-In deze handleiding gaan we ervan uit dat je TESTed gebruikt in Dodona.
-Als dat niet het geval is, verwijzen we je door naar de tutorial in de [tutorial in de repository](https://github.com/dodona-edu/universal-judge).
+In deze korte handleiding gaan we er van uit dat u TESTed binnen Dodona zult gebruiken.
+Als u TESTed als afzonderlijke tool wilt gebruiken, verwijzen we u door naar de tutorial in de [tutorial in de repository](https://github.com/dodona-edu/universal-judge).
 :::
 
-Om deze handleiding te volgen heb je het volgende nodig op je systeem:
+### Systeemvereisten
 
-- `git` - om de oefeningen op Dodona te krijgen. Meer informatie kan je vinden in [hoofdstuk 1 van het boek *Pro Git*](https://git-scm.com/book/nl/v2/Aan-de-slag-Git-installeren), dat uitlegt hoe je Git installeert voor verschillende besturingssystemen (Mac, Windows, Linux).
+Om deze handleiding te volgen hebt u het volgende nodig op uw systeem:
+
+- `git` - om de oefeningen naar Dodona te _pushen_. Meer informatie kunt u vinden in [hoofdstuk 1 van het boek *Pro Git*](https://git-scm.com/book/nl/v2/Aan-de-slag-Git-installeren), dat uitlegt hoe u Git installeert voor verschillende besturingssystemen (Mac, Windows, Linux).
 - een tekstverwerker (zoals Notepad++) om tekstbestanden aan te maken en te bewerken
 
-In deze tutorial leggen we uit hoe je een eenvoudige oefening kunt maken met TESTed en die in Dodona beschikbaar stellen.
-De oefening die we maken is "schrijf".
-Interessant is om de opgave te lezen:
+We zullen uitleggen hoe u een eenvoudige programmeeroefening kunt opstellen, die van automatische feedback wordt voorzien door TESTed, alsook hoe u deze oefening beschikbaar stelt op Dodona.
+De oefening heet "echo" en heeft de volgende opgave:
 
-> Schrijf een functie `schrijf` die steeds zijn argument naar standaarduitvoer schrijft.
-> Het argument van de functie zal steeds een string zijn.
+> Schrijf een functie `echo` die steeds haar argument naar standaarduitvoer schrijft.
 
-Een juiste oplossing in een aantal programmeertalen hiervoor is:
+Hier zijn een aantal correcte oplossingen voor deze oefeningen in een handvol programmeertalen:
 
 :::: tabs
 ::: tab Bash
 ```bash
-function schrijf {
+function echo {
     echo "$1"
 }
 ```
@@ -83,20 +81,20 @@ function schrijf {
 ```c
 #include <stdio.h>
 
-void schrijf(char* wat) {
+void echo(char* wat) {
     printf("%s", wat);
 }
 ```
 :::
 ::: tab Haskell
 ```haskell
-schrijf = putStrLn
+echo = putStrLn
 ```
 :::
 ::: tab Java
 ```java
 class Submission {
-    public static void schrijf(String wat) {
+    public static void echo(String wat) {
         System.out.println(wat);
     }
 }
@@ -104,126 +102,132 @@ class Submission {
 :::
 ::: tab JavaScript
 ```javascript
-function schrijf(wat) {
+function echo(wat) {
   console.log(wat);
 }
 ```
 :::
 ::: tab Kotlin
 ```kotlin
-fun schrijf(wat: String) {
+fun echo(wat: String) {
     println(wat)
 }
 ```
 :::
 ::: tab Python
 ```python
-def schrijf(argument):
+def echo(argument):
     print(argument)
 ```
 :::
 ::::
 
-Deze oplossingen willen we dus kunnen beoordelen met TESTed in Dodona.
+Deze oplossingen willen we beoordelen met TESTed.
 
 ### 1. Git-repository
 
-Dodona maakt gebruik van een Git-repository om oefeningen te beheren.
-Volg hiervoor de handleiding [_Een nieuwe repository met oefeningen maken_](/nl/guides/teachers/new-exercise-repo).
-Eens die gemaakt is, kan je terugkeren naar deze handleiding.
+Dodona gebruikt Git-repository's om oefeningen te beheren.
+Volg de handleiding [_Een nieuwe repository met oefeningen maken_](/nl/guides/teachers/new-exercise-repo)
+en keer terug naar deze handleiding eens uw repository gemaakt is.
 
 ### 2. Mappenstructuur
 
-In de repository die je net gemaakt hebt, moeten we de juiste mappenstructuur aanmaken.
-Maak deze nieuwe mappen in de repository:
+Nu moeten we de juiste mappenstructuur maken voor Dodona-oefeningen in de repository die u zonet maakte.
+Maak deze mappen:
 
 ```
-├── schrijf/          # Map voor de nieuwe oefening
+├── echo/          # Map voor de nieuwe oefening
 |   ├── evaluation/
 |   └── description/
 ```
 
-Dit is de mappenstructuur van Dodona; meer informatie vind je in de [referentie](/nl/references/exercise-directory-structure).
+Dit is de mappenstructuur van Dodona voor oefeningen.
+Meer informatie is te vinden in [_Oefeningmap-structuur_](/nl/references/exercise-directory-structure).
 
 ### 3. Configuratieopties
 
-Om aan Dodona duidelijk te maken dat we een oefening aan het opstellen zijn, moeten we een configuratiebestand toevoegen.
+Om Dodona duidelijk te maken dat we een oefening maken, moeten we een configuratiebestand toevoegen aan de map `echo`.
 Dit bestand bevat een aantal opties en wat metadata, die gebruikt worden door Dodona.
 
-Maak een nieuw bestand `config.json` aan in de map `schrijf`, met volgende inhoud:
+Maak een nieuw bestand `config.json` aan in de map `echo`, met volgende inhoud:
 
 ```json
 {
   "description": {
     "names": {
-      "en": "Write",
-      "nl": "Schrijf"
+      "en": "Echo",
+      "nl": "Echo"
     }
   },
   "evaluation": {
-    "plan_name": "testplan.json"
+    "plan_name": "tests.json"
   },
   "programming_language": "python",
   "access": "private"
 }
 ```
 
-We doen hier vier dingen:
+Dit configuratiebestand specifieert, in volgorde:
 
-1. We geven een naam aan de oefening, in het Nederlands en in het Engels.
-2. We geven mee waar het testplan zich bevindt in de oefening (`testplan.json`).
-   Dit is altijd relatief ten opzichte van de map `schrijf/evaluation`.
-3. We stellen de standaardprogrammeetaal in op Python. Hoewel TESTed meerdere programmeertalen ondersteunt, is dat voor Dodona nog niet het geval.
-4. We stellen in dat het om een private oefening gaat.
+1. Een naam voor de oefening in het Nederlands en het Engels.
+2. Het pad naar het testplan (`tests.json`), relatief ten opzichte van de map `echo/evaluation`.
+3. We stellen de standaardprogrammeetaal in op Python.
+   Hoewel TESTed meerdere programmeertalen ondersteunt,
+   is Dodona beperkt tot één programmeertaal per oefening.
+4. Private toegang voor de oefening.
+   We beperken de toegang omdat dit een handleiding is,
+   maar we moedigen het publiek beschikbaar stellen van oefeningen op Dodona aan.
 
-### 4. De opgave schrijven
+Zie [_Oefeningconfiguratie_](/nl/references/exercise-config) voor meer details over de configuratieopties voor Dodona-oefeningen.
+Ook de [opties die eigen zijn aan TESTed](/nl/tested/exercise-config) kunnen interessant zijn.
 
-De opgave van een oefening beschrijft voor de studenten wat ze moeten doen.
-Dit is opnieuw iets van Dodona; er is niets specifiek voor TESTed aan.
-Meer informatie is opnieuw te vinden in de [relevante handleiding](/nl/references/exercise-description).
+### 4. Opgave
 
-Voor het gemak zullen we de opgave van hierboven overnemen, aangevuld met een voorbeeldje.
-Maak dus het bestand `schrijf/description/description.nl.md` aan met volgende inhoud:
+De opgave zegt hoe studenten de oefening moeten oplossen.
+We zullen de opgave van hiervoor gebruiken en een voorbeeld toevoegen.
+Maak een bestand `echo/description/description.nl.md` met volgende inhoud:
 
 ````markdown
-Schrijf een functie `schrijf` die steeds zijn argument naar standaarduitvoer schrijft.
-
-Het argument van de functie zal steeds een string zijn.
+Schrijf een functie `echo` die steeds haar argument naar standaarduitvoer schrijft.
 
 ### Voorbeeld in Python
 
 ```pycon
->>> schrijf("5"); 
+>>> echo("5"); 
 "5"
->>> schrijf("ok");
-"ok"
+>>> echo("OK");
+"OK"
 ```
 ````
 
-Ter controle, de bestandsstructuur moet er als volgt uitzien na deze stap:
+Ter controle, de bestandsstructuur moet er nu als volgt uitzien:
 
 ```
-├── schrijf/
+├── echo/
 |   ├── config.json
 |   ├── evaluation/
 |   ├── description/
 |   |   └── description.nl.md
 ```
 
-### 5. Het testplan opstellen
+Dit is opnieuw Dodona-specifiek en heeft niets te maken met TESTed.
+Zie [_Oefeningbeschrijvingen_](/nl/references/exercise-description) voor meer informatie over opgaven voor Dodona-oefeningen.
 
-Nu komen we bij het belangrijkste deel van een oefeningen opstellen: het testplan.
-Dit testplan bevat alle testgevallen die uitgevoerd zullen worden op een oplossing om te controleren of deze oplossing al dan niet juist is.
+### 5. Testplan
 
-Om deze tutorial kort te houden, beperken we ons tot één testgeval, maar in een echte oefeningen zullen dit er meer zijn.
+Een testplan opstellen is het deel van ontwerpen van een Dodona-oefening dat sterk afhangt van welke judge er gebruikt wordt.
+Daarom moeten we het TESTed-formaat voor testplannen volgen.
+Een testplan bevat alle testgevallen die uitgevoerd zullen worden op een oplossing om te controleren of deze oplossing al dan niet juist is.
 
-Maak een nieuw bestand `evaluation/testplan.json` met volgende inhoud:
+Om deze handleiding kort te houden, beperken we ons tot een testplan met één enkel testgeval.
+In een echte oefening zou het testplan veel meer testgevallen bevatten.
+Maak een nieuw bestand `evaluation/tests.json` met volgende inhoud:
 
 ```json
 {
  "tabs": [
   {
-   "name": "Schrijf",
+   "name": "Echo",
    "runs": [
     {
      "contexts": [
@@ -232,7 +236,7 @@ Maak een nieuw bestand `evaluation/testplan.json` met volgende inhoud:
         {
          "input": {
           "type": "function",
-          "name": "schrijf",
+          "name": "echo",
           "arguments": [
            {
             "type": "text",
@@ -257,39 +261,38 @@ Maak een nieuw bestand `evaluation/testplan.json` met volgende inhoud:
 }
 ```
 
-Dit testplan definieert een aantal dingen:
+Dit testplan definieert zegt:
 
-1. We hebben één tabblad, met als naam _Schrijf_.
-2. In dat tabblad definiëren we 1 testgevallen.
-3. In het testgeval roepen we de functie `schrijf` op met één argument, de string `input-1`.
-   Eigenlijk staat hier `schrijf("input-1")`.
-4. We verwachten `input-1` te vinden op stdout.
+1. Alle feedback is verzameld in één tabblad met naam _Echo_.
+2. Het tabblad bevat feedback voor één testgeval.
+3. Het testgeval roept we de functie `echo` op met een string `input-1` als argument.
+   Conceptueel is dit equivalent met `echo("input-1")` uitvoeren in Python.
+4. Het verwachte resultaat is dat de tekst `input-1` op stdout geschreven wordt.
 
 Nu ziet de bestandsstructuur er als volgt uit:
 
 ```
-├── schrijf/
+├── echo/
 |   ├── config.json
 |   ├── evaluation/
-|   |   └── testplan.json
+|   |   └── tests.json
 |   ├── description/
 |   |   └── description.nl.md
 ```
 
-### 6. Oefening op Dodona zetten
+### 6. Toevoegen aan Dodona
 
-Nu moeten we deze wijzigingen committen met `git`:
+We committen de nieuwe oefening met de volgende commando's van `git`:
 
 ```bash
 $ git add .
 $ git commit -m "Mijn eerste oefening"
 ```
 
-Vervolgens moeten we de wijzigingen nog naar je repository pushen:
+Vervolgens pushen we de wijzigingen in de repository naar Dodona:
 
 ```bash
 $ git push
 ```
 
-Deze oefening is nu klaar.
-Als alles goed ging, zul je deze oefening nu kunnen gebruiken op Dodona.
+Deze oefening is nu helemaal klaar en beschikbaar op Dodona als een private oefening, klaar om aan de leerpaden van uw cursussen toegevoegd te worden.

--- a/nl/tested/README.md
+++ b/nl/tested/README.md
@@ -1,6 +1,6 @@
 ---
-title: TESTed judge
-description: "TESTed judge"
+title: TESTed-judge
+description: "De TESTed-judge"
 sidebarDepth: 2
 ---
 

--- a/nl/tested/exercise-config/README.md
+++ b/nl/tested/exercise-config/README.md
@@ -1,16 +1,16 @@
 ---
-title: Configuratie-opties voor oefeningen
-description: "De configuratie-opties ondersteund door TESTed"
+title: Configuratieopties voor oefeningen
+description: "Configuratieopties voor oefeningen met TESTed"
 ---
 
-# Configuratie-opties voor oefeningen in TESTed
+# Configuratieopties voor oefeningen
 
-Naast de standaardopties van Dodona zijn er een aantal opties die eigen aan TESTed zijn.
+Naast de [algemene configuratieopties](/nl/references/exercise-config) voor oefeningen van Dodona, zijn er een aantal configuratie-opties voor TESTed.
 
 ## Testplan
 
-De enige verplichte optie is de naam van het testplan meegeven.
-Dit moet binnen het `evaluation`-blok:
+De standaardlocatie van een testplan voor TESTed is een JSON-bestand `plan.json` in de map `evaluation` van de oefening.
+Het optionele veld `testplan` in het `evaluation`-blok kan gebruikt worden om een alternatieve locatie in te stellen, relatief tegenover de map `evaluation`.
 
 ```json
 {
@@ -20,76 +20,27 @@ Dit moet binnen het `evaluation`-blok:
 }
 ```
 
-Een volledige beschrijving van het testplan is beschikbaar in de [handleiding (Engels)](/en/tested/json).
+Zie [_Formaat voor testplannen_](/nl/tested/json) voor een gedetailleerde beschrijving van het formaat voor testplannen voor TESTed.
 
-## General opties
+## Algemene opties
 
-Daarnaast kan je bepaalde delen van het gedrag van TESTed aanpassen door opties mee te geven in een `options`-blok.
-In de volgende paragrafen bespreken we de verschillende opties.
-Hun specificatie wordt vastgelegd in onderstaand [JSON Schema](https://json-schema.org/).
+Het `evaluation`-blok ondersteunt een `option`-object met velden die het gedrag van TESTed beïnvloeden.
+We overlopen deze opties hieronder.
 
-```json
-{
-  "title": "OptionsModel",
-  "$ref": "#/definitions/Options",
-  "definitions": {
-    "ExecutionMode": {
-      "title": "ExecutionMode",
-      "description": "An enumeration.",
-      "enum": [
-        "batch",
-        "context"
-      ],
-      "type": "string"
-    },
-    "Options": {
-      "title": "Options",
-      "type": "object",
-      "properties": {
-        "mode": {
-          "default": "batch",
-          "allOf": [
-            {
-              "$ref": "#/definitions/ExecutionMode"
-            }
-          ]
-        },
-        "allow_fallback": {
-          "title": "Allow Fallback",
-          "default": true,
-          "type": "boolean"
-        },
-        "language": {
-          "title": "Language",
-          "default": {},
-          "type": "object",
-          "additionalProperties": {
-            "type": "object"
-          }
-        },
-        "linter": {
-          "title": "Linter",
-          "default": true,
-          "type": "boolean"
-        }
-      }
-    }
-  }
-}
-```
+### `options.mode`
 
-### Compilatiemodus
+Het veld `mode` geeft aan hoe testcode gegenereerd en uitgevoerd moeten worden (samen met de ingediende oplossing).
+Twee modi worden ondersteund:
 
-Het veld `mode` geeft aan hoe uitvoerbare bestanden (testbestanden en ingediende oplossingen) moeten gecompileerd moet worden.
-Daarvoor biedt TESTed twee mogelijkheden aan:
+* `batch` (standaard): Alle testcode van een tabblad wordt gegenereerd en gecompileerd in één compilatie-eenheid (batchcompilatie).
+* `context`: Testcode wordt gegenereerd en gecompileerd per context (contextuele compilatie).
 
-* `batch`: Alle uitvoerbare bestanden in één keer compileren.
-* `context`: Elk uitvoerbare bestanden afzonderlijk compileren (individuele compilatie).
+Het compilatieproces is sneller bij batchcompilatie dan met contextuele compilatie,
+maar kan falen als een ingediende oplossing niet aan alle vereisten van de oefening voldoet.
+Als een oefening bijvoorbeeld vereist dat twee functie geïmplementeerd worden, maar de ingediende oplossing implementeert er slechts één, zal dit bij oplossingen in Java leiden tot compilatiefouten.
+Zie het volgende veld voor een oplossing.
 
-Het voornaamste voordeel van de batchcompilatie is dat het sneller is dat de individuele compilatie.
-Standaard zal TESTed alle uitvoerbare bestanden in één keer compileren.
-
-Voorbeeld (individueel compileren):
+Hier is een voorbeeld dat contextuele compilatie gebruikt:
 
 ```json
 {
@@ -101,14 +52,13 @@ Voorbeeld (individueel compileren):
 }
 ```
 
-### Fallback voor compilatie
+### `options.allow_fallback`
 
-Bij `batch`-compilatie kan ingesteld worden dat TESTed mag teruggevallen op individuele compilatie als de `batch`-compilatie faalt.
-Dit kan bijvoorbeeld nuttig zijn als een oplossing nog niet alle functies heeft geïmplementeerd.
-Hiervoor gebruik je het veld `allow_fallback`.
-Standaard mag TESTed terugvallen op individuele compilatie als de `batch`-compilatie faalt.
+Als het Booleaanse veld `allow_fallback` op `true` staat (de standaardwaarde),
+zal TESTed automatisch contextuele compilatie gebruiken als de batchcompilatie faalt.
+Dit kan nuttig zijn om ingediende oplossingen te evalueren die niet alle vereisten implementeren.
 
-Voorbeeld (fallback voor compilatie uitgeschakeld):
+Hier is een voorbeeld dat het terugvallen op de contextuele compilatie uitschakelt:
 
 ```json
 {
@@ -123,8 +73,8 @@ Voorbeeld (fallback voor compilatie uitgeschakeld):
 
 ## Linters
 
-Bij de [configuratie van een programmeertaal voor TESTed](../new-programming-language)
-kan ook een [linter](https://en.wikipedia.org/wiki/Lint_(software)) geconfigureerd worden.
+Bij het [toevoegen van een nieuwe programmeertaal aan TESTed](/nl/tested/new-programming-language)
+is het ook mogelijk een [linter](https://en.wikipedia.org/wiki/Lint_(software)) toe te voegen, die TESTed gebruikt om statische code-analyze uit te voeren bij het beoordelen van een ingediende oplossing.
 Dit zijn de linters die TESTed op dit moment gebruikt:
 
 | Programmeertaal | Linter                                                 |
@@ -137,7 +87,9 @@ Dit zijn de linters die TESTed op dit moment gebruikt:
 | Kotlin          | [Ktlint](https://ktlint.github.io/)                    |
 | Python          | [Pylint](https://pylint.pycqa.org/en/latest/)          |
 
-Bij de configuratie van een oefening kan je in het veld `linter` globaal de linters uit- of inschakelen. Voorbeeld (alle linters uitschakelen):
+Het Booleaanse veld `options.linter` kan gebruikt worden om linters in (`true`) of uit (`false`) te schakelen voor een programmeeroefening,
+voor alle programmeertalen samen ofwel voor individuele talen.
+Het is een voorbeeld dat linters uitschakelt voor alle programmeertalen:
 
 ```json
 {
@@ -149,7 +101,7 @@ Bij de configuratie van een oefening kan je in het veld `linter` globaal de lint
 }
 ```
 
-De linters kunnen ook per programmeertaal in-/uitgeschakeld worden in de programmeertaal-specifieke opties. Voorbeeld (alleen linting voor JavaScript):
+Hier is een voorbeeld dat enkel de linter voor JavaScript inschakelt:
 
 ```json
 {
@@ -166,17 +118,17 @@ De linters kunnen ook per programmeertaal in-/uitgeschakeld worden in de program
 }
 ```
 
-## Programmeertaal-specifieke opties
+## Opties voor individuele programmeertalen
 
-Naast algemene configuratieopties, kunnen individuele programmeertalen ook eigen opties hebben.
-Onderstaande opties zijn momenteel beschikbaar.
+De modules voor de programmeertalen in TESTed kunnen eigen opties hebben.
+Hieronder is een overzicht van de opties voor elke programmeertaal die momenteel door TESTed ondersteund wordt.
 
 ### Bash
 
-Met de optie `shellcheck_config` kan je een Shellcheck-configuratiebestand meegeven, dat zal gebruikt worden om de linter in te stellen.
-Dit bestand moet zich in de map `evaluation` van de oefening bevinden.
+In het veld `shellcheck_config` kan de locatie van een configuratiebestand voor Shellcheck gegeven worden, relatief ten opzicht van de `evaluation`-map van de oefening.
+TESTed zal dit configuratiebestand gebruiken bij het uitvoeren van de linter op ingediende oplossingen in Bash.
+Hier is een voorbeeld dat het bestand `shellcheckrc` instelt als configuratiebestand voor Shellcheck:
 
-Voorbeeld (Shellcheck-configuratie):
 ```json
 {
   "evaluation": {
@@ -193,10 +145,10 @@ Voorbeeld (Shellcheck-configuratie):
 
 ### Haskell
 
-Met de optie `hlint_config` kan je een HLint-configuratiebestand meegeven, dat zal gebruikt worden om de linter in te stellen.
-Dit bestand moet zich in de map `evaluation` van de oefening bevinden.
+In het veld `hlint_config` kan de locatie van een configuratiebestand voor HLint gegeven worden, relatief ten opzicht van de `evaluation`-map van de oefening.
+TESTed zal dit configuratiebestand gebruiken bij het uitvoeren van de linter op ingediende oplossingen in Haskell.
+Hier is een voorbeeld dat het bestand `hlint.config.yaml` instelt als configuratiebestand voor HLint:
 
-Voorbeeld (HLint-configuratie):
 ```json
 {
   "evaluation": {
@@ -213,10 +165,10 @@ Voorbeeld (HLint-configuratie):
 
 ### Java
 
-Met de optie `checkstyle_config` kan je een Checkstyle-configuratiebestand meegeven, dat zal gebruikt worden om de linter in te stellen.
-Dit bestand moet zich in de map `evaluation` van de oefening bevinden.
+In het veld `checkstyle_config` kan de locatie van een configuratiebestand voor Checkstyle gegeven worden, relatief ten opzicht van de `evaluation`-map van de oefening.
+TESTed zal dit configuratiebestand gebruiken bij het uitvoeren van de linter op ingediende oplossingen in Java.
+Hier is een voorbeeld dat het bestand `java_style.xml` instelt als configuratiebestand voor Checkstyle:
 
-Voorbeeld (Checkstyle-configuratie):
 
 ```json
 {
@@ -234,10 +186,9 @@ Voorbeeld (Checkstyle-configuratie):
 
 ### JavaScript
 
-Met de optie `eslint_config` kan je een ESLint-configuratiebestand meegeven, dat zal gebruikt worden om de linter in te stellen.
-Dit bestand moet zich in de map `evaluation` van de oefening bevinden.
-
-Voorbeeld (ESLint-configuratie):
+In het veld `eslint_config` kan de locatie van een configuratiebestand voor ESLint gegeven worden, relatief ten opzicht van de `evaluation`-map van de oefening.
+TESTed zal dit configuratiebestand gebruiken bij het uitvoeren van de linter op ingediende oplossingen in JavaScript.
+Hier is een voorbeeld dat het bestand `eslintrc.yaml` instelt als configuratiebestand voor ESLint:
 
 ```json
 {
@@ -255,17 +206,14 @@ Voorbeeld (ESLint-configuratie):
 
 ### Kotlin
 
-Voor Kotlin zijn er een aantal opties voor de linter `ktlint`:
+TESTed ondersteunt volgende velden voor de linter bij Kotlin (`ktlint`):
 
-- `editorconfig`: Naam van een `.editorconfig`-bestand (zie <https://editorconfig.org/>) in de map `evaluation` van de oefening.
-- `disabled_rules_ktlint`: Lijst van regels die *ktlint* moeten negeren. Kan ook
-  ingesteld worden als een kommagescheiden string van regels.
-- `ktlint_ruleset`: Bestandsnaam van een JAR-bestand met extra regels. Dit
-  bestand moet in de map `evaluation` van de oefening geplaatst worden.
-- `ktlint_experimental`: Boolean die aangeeft of *ktlint* ook experimentele
-  regels moet gebruiken. Standaard zal *ktlint* experimentele regels gebruiken.
+- `editorconfig`: Locatie en naam van een `.editorconfig`-bestand (zie <https://editorconfig.org/>), relatief ten opzichte van de `evaluation`-map van de oefening.
+- `disabled_rules_ktlint`: Regels die _ktlint_ moeten negeren, ofwel als een lijst van strings, ofwel als één string die door komma's gescheiden wordt.
+- `ktlint_ruleset`: Locatie en naam van een JAR-bestand met extra regels, relatief ten opzichte van de `evaluation`-map van de oefening.
+- `ktlint_experimental`: Booleaanse waarde die aangeeft of `ktlint` ook experimentele regels moet gebruiken (`true`, de standaardwaarde) of niet (`false`).
 
-Voorbeeld (KTLint-configuratie):
+Hier is een voorbeeld dat het gebruik van een aantal van deze velden toont:
 
 ```json
 {
@@ -286,10 +234,9 @@ Voorbeeld (KTLint-configuratie):
 
 ### Python
 
-Met de optie `pylint_config` kan je een PyLint-configuratiebestand meegeven, dat zal gebruikt worden om de linter in te stellen.
-Dit bestand moet zich in de map `evaluation` van de oefening bevinden.
-
-Voorbeeld (PyLint-configuratie):
+In het veld `pylint_config` kan de locatie van een configuratiebestand voor PyLint gegeven worden, relatief ten opzicht van de `evaluation`-map van de oefening.
+TESTed zal dit configuratiebestand gebruiken bij het uitvoeren van de linter op ingediende oplossingen in Python.
+Hier is een voorbeeld dat het bestand `pylint.rc` instelt als configuratiebestand voor PyLint:
 
 ```json
 {
@@ -307,11 +254,11 @@ Voorbeeld (PyLint-configuratie):
 
 ## Volledig voorbeeld
 
-Hieronder zie je een volledig configuratiebestand van een oefening (`config.json`):
+Hieronder is een voorbeeld van een volledig configuratiebestand (`config.json`) voor een programmeeroefeningen voor Dodona dat gebruik maakt van TESTed voor automatische feedback:
 
 ```json
 {
-  "access": "private",
+  "access": "public",
   "description": {
     "names": {
       "en": "My exercise",
@@ -320,7 +267,7 @@ Hieronder zie je een volledig configuratiebestand van een oefening (`config.json
   },
   "evaluation": {
     "handler": "TESTed",
-    "plan_name": "plan.yaml",
+    "plan_name": "plan.json",
     "options": {
       "mode": "batch",
       "allow_fallback": true,

--- a/nl/tested/json/README.md
+++ b/nl/tested/json/README.md
@@ -1,11 +1,18 @@
 ---
-title: "[en] Volledige testplannen (JSON)"
-description: "Maak volledige testplannen voor TESTed"
+title: "[en] Formaat voor testplannen"
+description: "Maak testplannen voor TESTed"
 ---
-# Testplannen in TESTed (JSON)
+# Formaat voor testplannen
 
-::: warning Enkel Engels
-Deze handleiding is enkel in het Engels beschikbaar.
+::: warning Engelstalige referentie
+De volledige referentie is enkel beschikbaar in het Engels.
 [Ga naar de Engelstalige versie.](/en/tested/json)
 :::
 
+Een testplan voor TESTed legt vast welke testgevallen uitgevoerd worden op een ingediende oplossing.
+TESTed verschilt van andere judges doordat testplannen niet afhankelijk zijn van één bepaalde programmeertaal.
+Derhalve volstaat één testplan om ingediende oplossingen in verschillende programmeertalen van dezelfde oefening te evalueren.
+
+Het formaat voor testplannen voor TESTed is formeel vastgelegd door [deze Python-module](https://github.com/dodona-edu/universal-judge/blob/master/tested/testplan.py).
+Deze module kan ook een _JSON Schema_ genereren om het valideren van testplannen makkelijker te maken.
+The [repository met de broncode](https://github.com/dodona-edu/universal-judge/tree/master/exercise) van TESTed bevat een aantal voorbeelden van testplannen.

--- a/nl/tested/new-programming-language/README.md
+++ b/nl/tested/new-programming-language/README.md
@@ -1,9 +1,9 @@
 ---
 title: "[en] Nieuwe programmeertaal"
-description: "Toevoegen van een nieuwe programmeertaal aan TESTed"
+description: "Configureren van een nieuwe programmeertaal aan TESTed"
 ---
 
-# Configuratie van een programmeertaal
+# Nieuwe programmeertalen toevoegen
 
 ::: warning Enkel Engels
 Deze handleiding is enkel in het Engels beschikbaar.

--- a/nl/tested/types/README.md
+++ b/nl/tested/types/README.md
@@ -3,17 +3,29 @@ title: Ondersteuning gegevenstypes
 description: "De verschillende gegevenstypes ondersteund door TESTed"
 ---
 
-# Ondersteuning voor gegevenstypes in TESTed
+# Ondersteuning voor gegevenstypes
 
-::: tip Bijgewerkte informatie
-Deze data werden verzameld van de programmeertaalmodules in TESTed.
-Zij bevatten de meest recente informatie over de gegevenstypes.
-:::
-
-Deze referentiegids toont welke gegevenstypes in verschillende programmeertalen gebruikt worden en hoe ze overeenkomen met de gegevenstypes van TESTed.
+Deze referentie geeft een overzicht van alle gegevenstypes in TESTed (basistypes en geavanceerde types).
+Ze legt ook uit hoe de verschillende types zich vertalen naar de programmeertalen die momenteel door TESTed ondersteund worden.
 
 ## Basistypes
 
+Basistypes stellen abstracte gegevenstypes voor, zoals integers, maar niet specifieke implementaties ervan, zoals een _unsigned 8-bit integer_.
+Ze worden gebruikt als het standaardtype voor een concept in een programmeertaal, maar elke programmeertaal kan meerdere types hebben voor eenzelde basistype.
+
+TESTed supports the following basic types:
+
+- `integer`: een integer
+- `real`: een reëel getal number
+- `boolean`: een Booleaanse waarde
+- `text`: tekstuele gegevens (bv. strings)
+- `sequence`: een geordende reeks waarden
+- `set`: een ongeordende verzameling unieke waarden
+- `map`: een verzameling van sleutel-waardeparen
+- `nothing`: een voorstelling voor "niets", dus geen waarde
+- `any`: eender welk gegevenstype. **Opmerking**: u kunt dit niet gebruiken in testplannen. Het wordt enkel gebruikt om onbekende returnwaarden aan te duiden.
+
+Onderstaande tabel geeft een overzicht van alle basistypes die ondersteund worden door TESTed.
 In de eerste kolom staan de gegevenstypes van TESTed, gevolgd door een kolom voor elke programmeertaal.
 
 | TESTed   | Python  | JavaScript | Java          | Kotlin    | Haskell   | C        | Bash   |
@@ -32,8 +44,34 @@ In de eerste kolom staan de gegevenstypes van TESTed, gevolgd door een kolom voo
 
 ## Geavanceerde types
 
-De eerste kolom toont de naam van het geavanceerde type (onder de tabel staan een aantal definities van deze types).
-De tweede kolom toont wat het basistype van dit type is.
+Geavanceerde types stellen specifieke implementaties van gegevenstypes voor, zoals een _unsigned 8-bit integer_.
+Elk geavanceerd type komt overeen met hoogstens één type in een programmeertaal, en sommige programmeertalen hebben geen ondersteuning voor bepaalde types.
+
+Momenteel ondersteunt TESTed volgende types:
+
+- `int8`: 8-bit integers (signed)
+- `uint8`: 8-bit natuurlijke getallen (unsigned)
+- `int16`: 16-bit integers (signed)
+- `uint16`: 16-bit natuurlijke getallen (unsigned)
+- `int32`: 32-bit integers (signed)
+- `uint32`: 32-bit natuurlijke getallen (unsigned)
+- `int64`: 64-bit integers (signed)
+- `uint64`: 64-bit natuurlijke getallen (unsigned)
+- `bigint`: integers zonder onder- en bovengrens (signed)
+- `single_precision` - IEEE 754 enkele precisie zwevendekommagetal
+- `double_precision` - IEEE 754 dubbele precisie zwevendekommagetal
+- `double_extended` - IEEE 754 "double extended" precisie zwevendekommagetal
+- `fixed_precision` - vastekommagetal
+- `array`: een _mutable_ reeks met vaste grootte
+- `list`: een _mutable_ reeks met veranderlijke grootte
+- `tuple`: een _immutable_ reeks
+- `char`: één teken
+- `undefined`: gebruikt voor talen die een verschil hebben tussen `null` en `undefined`, zoals in JavaScript
+
+Onderstaande tabel geeft een overzicht van alle geavanceerde types die ondersteund worden door TESTed.
+De eerste kolom bevat alle geavanceerde types, de tweede kolom toont wat het basistype van dit type is.
+De andere kolommen tonen de overeenkomstige types in de verschillende programmeertalen.
+De uitleg over de gebruikte symbolen in deze kolommen staat onder de tabel.
 
 | TESTed           | Basic    | Python    | JavaScript  | Java         | Kotlin       | Haskell            | C                | Bash |
 |------------------|----------|-----------|-------------|--------------|--------------|--------------------|------------------|------|
@@ -49,35 +87,22 @@ De tweede kolom toont wat het basistype van dit type is.
 | single_precision | real     | +         | +           | `float`      | `Float`      | `Float`            | `float`          | -    |
 | double_precision | real     | +         | +           | `double`     | `Double`     | `Double`           | `double`         | -    |
 | double_extended  | real     | +         | +           | +            | +            | -                  | `double double`  | -    |
-| fixed_precision  | real     | `Decimal` | -           | `BigDecimal` | `BigDecimal` | -                  | -                | -    |
+| fixed_precision  | rational | `Decimal` | -           | `BigDecimal` | `BigDecimal` | -                  | -                | -    |
 | array            | sequence | +         | +           | `array`      | `Array`      | -                  | -                | -    |
 | list             | sequence | `List`    | +           | `List`       | `List`       | `[]`²              | -                | -    |
 | tuple            | sequence | `Tuple`   | +           | +            | +            | `()`¹              | -                | -    |
 | char             | text     | +         | +           | `char`       | `Char`       | `Char`             | `char`           | +    |
 | undefined        | nothing  | +         | `undefined` | +            | +            | +                  | +                | -    |
 
-¹ ingebouwd type voor tuples
+¹ ingebouwd type voor tuple  
+² ingebouwd type voor list
 
-Een "+" (plusteken) betekent dat de programmeertaal beperkte ondersteuning heeft (`reduced`).
-Dit betekent vaak dat er geen eigen type bestaat in de programmeertaal, maar dat oefeningen die het type gebruiken wel gemaakt kunnen worden in de taal.
-Een voorbeeld zijn tuples: heel wat talen hebben er geen eigen type voor, maar de oefeningen kunnen wel opgelost worden door het basistype (een `sequence`) te gebruiken.
-Een oefening die tuples gebruikt zal bijvoorbeeld in Java ook oplosbaar zijn, omdat lijsten aanvaard worden.
+Een plusteken (+) betekent dat de programmeertaal **beperkte ondersteuning** heeft voor het gegevenstype.
+Dit betekent vaak dat er geen eigen type bestaat in de programmeertaal, maar dat oefeningen die het type gebruiken wel opgelost kunnen worden in de taal, doordat TESTed terugvalt op het basistype.
+Laten we tuples als voorbeeld nemen.
+Veel programmeertalen hebben geen rechtstreekse ondersteuning voor types, maar oefeningen die ervan gebruik maken kunnen opgelost worden voor het basistype (`sequence`) te gebruiken.
+Een oefening met tuples kan in Java bijvoorbeeld opgelost worden door `List` te gebruiken.
 
-Een "-" (minteken) betekent dat de programmeertaal geen ondersteuning heeft (`unsupported`).
-Dit betekent dat een oefening die dergelijke types gebruikt niet oplosbaar zal zijn in de programmeertaal.
-Zo zal JavaScript geen `fixed_precision` ondersteunen, dus oefeningen die dat nodig hebben zullen niet opgelost kunnen worden in JavaScript.
-
-Dit zijn de definities van de types:
-
-- `intN` - signed integers, minstens `N` bits; bv. `int16` moest minstens 16 bits hebben
-- `uintN` - unsigned integers, minstens `N` bits
-- `bigint` - integers van arbitraire grootte
-- `single_precision` - IEEE 754 enkele precisie
-- `double_precision` - IEEE 754 dubbele precisie
-- `double_extended` - IEEE 754 dubbele extended precisie
-- `fixed_precision` - vastekommagetal
-- `array` - aaneengesloten stuk geheugen met vaste grootte voor elementen
-- `list` - geordende reeks elementen, waarbij dubbels toegelaten zijn
-- `tuple` - niet-wijzigbare lijst
-- `char` - een enkel teken
-- `undefined` - anders dan `null`, zoals in JavaScript
+Een minteken (-) betekent dat de programmeertaal **geen ondersteuning** heeft voor het type.
+Dit betekent dat oefeningen die dergelijke types gebruikt niet oplosbaar zullen zijn in die programmeertaal.
+Zo zal een oefening die vastekommagetallen gebruikt niet oplosbaar zijn in JavaScript.


### PR DESCRIPTION
This is a review of the TESTed documentation, also including the suggestions made by @pdawyndt (in.

In most cases, the changes are language-related.

However, in the documentation for the test suites (the json format), the changes were more significant. Hopefully, the documentation is now easier to read for humans.
For example, I removed all the JSON Schema fragments, as I assume these aren't useful or pleasant reading for humans, while tools need to full JSON Schema, not the split fragments from the documentation.
I also added examples in some places where I deemed them useful.