### PR TITLE
Add judge overview

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -230,6 +230,7 @@ function getReferencesSidebar(lang, groupTitle, FirstItem) {
         'repository-directory-structure/',
         'exercise-directory-structure/',
         'python-judge/',
+        'judges/',
       ]
     },
     `/${lang}/tested/`

--- a/en/guides/creating-a-judge/README.md
+++ b/en/guides/creating-a-judge/README.md
@@ -8,6 +8,8 @@ description: "Tutorial: creating a judge"
 This is an advanced guide aimed at developers. You will probably not need the info on this page. If you plan to create a judge, please contact us at <a href="mailto:dodona@ugent.be">dodona@ugent.be</a>.
 :::
 
+Before you create your own judge, please check if there is no [existing judge](en/references/judges) that can be used for your exercises.
+
 For each judge in Dodona, there is one git repository. This git repository requires a [predefined structure](#_2-repository-structure) and [interface](#_3-judge-interface) to fit into Dodona. Once created, a judge should be [added to Dodona](#_1-adding-a-judge), so it can be used for exercises.
 
 ## 1. Adding a Judge

--- a/en/guides/creating-a-judge/README.md
+++ b/en/guides/creating-a-judge/README.md
@@ -8,7 +8,7 @@ description: "Tutorial: creating a judge"
 This is an advanced guide aimed at developers. You will probably not need the info on this page. If you plan to create a judge, please contact us at <a href="mailto:dodona@ugent.be">dodona@ugent.be</a>.
 :::
 
-Before you create your own judge, please check if there is no [existing judge](en/references/judges) that can be used for your exercises.
+Before you create your own judge, please check if there is no [existing judge](/en/references/judges) that can be used for your exercises.
 
 For each judge in Dodona, there is one git repository. This git repository requires a [predefined structure](#_2-repository-structure) and [interface](#_3-judge-interface) to fit into Dodona. Once created, a judge should be [added to Dodona](#_1-adding-a-judge), so it can be used for exercises.
 

--- a/en/guides/teachers/new-exercise-repo/README.md
+++ b/en/guides/teachers/new-exercise-repo/README.md
@@ -42,4 +42,4 @@ The only thing left to do is adding this URL to GitHub. To do this, open your re
 You are now ready to add exercises and reading activities to your repository. If all goes well, they should show up automatically on Dodona.
 
 To find out more about how to create exercises in your repository, checkout the [repository directory structure](/en/references/repository-directory-structure) reference.
-The specific format of the test for your exercises depends on your chosen judge. You can find on overview of all our supported judges, with links to their documentation, on the [judge overview](/en/references/judge/).
+The specific format of the test for your exercises depends on your chosen judge. You can find on overview of all our supported judges, with links to their documentation, on the [judge overview](/en/references/judges).

--- a/en/guides/teachers/new-exercise-repo/README.md
+++ b/en/guides/teachers/new-exercise-repo/README.md
@@ -13,7 +13,7 @@ A first step is thus to create a git repository. You can easily do this on [gith
 
 ## 2. Add the repository to Dodona
 
-All staff on Dodona has a `Repositories` link in the sidebar of the Dodona website, which takes you to an [overview of the repositories](https://dodona.ugent.be/en/repositories/). To add a new repository, hit the big plus button on the top.
+All staff on Dodona has a `Repositories` link in the sidebar of the Dodona website, which takes you to an [overview of your repositories](https://dodona.ugent.be/en/repositories/). To add a new repository, hit the big plus button on the top.
 
 ![add repository](./add-repository.png)
 
@@ -40,3 +40,6 @@ The only thing left to do is adding this URL to GitHub. To do this, open your re
 ## 4. Create learning activities
 
 You are now ready to add exercises and reading activities to your repository. If all goes well, they should show up automatically on Dodona.
+
+To find out more about how to create exercises in your repository, checkout the [repository directory structure](/en/references/repository-directory-structure) reference.
+The specific format of the test for your exercises depends on your chosen judge. You can find on overview of all our supported judges, with links to their documentation, on the [judge overview](/en/references/judge/).

--- a/en/references/README.md
+++ b/en/references/README.md
@@ -11,6 +11,7 @@ Here you can find up-to-date descriptions of the Dodona config files and directo
 * [Exercise config](exercise-config)
 * [Repository directory structure](repository-directory-structure)
 * [Exercise directory structure](exercise-directory-structure)
+* [Judges](judges)
 
 ## In Dutch
 * [Python judge](python-judge)

--- a/en/references/exercise-config/README.md
+++ b/en/references/exercise-config/README.md
@@ -10,7 +10,7 @@ Dodona allows setting the configuration of an **exercise** and a **reading activ
 ## Config file structure for exercises
 
 - **`type`**: Must be set to `exercise` for exercises. Defaults to `exercise` if not present.
-- **`programming_language`** (string): the programming language of the exercise, used for syntax highlighting and correct file extensions
+- **`programming_language`** (string): the programming language of the exercise, used for syntax highlighting and correct file extensions. The available programming languages can be found [here](https://dodona.ugent.be/en/programming_languages/).
 - **`access`** (`public` or `private`): determines who can use this exercise
   - `public`: any other teacher on Dodona can use this exercise
   - `private`: only teachers with explicit permission can use this exercise
@@ -19,7 +19,7 @@ Dodona allows setting the configuration of an **exercise** and a **reading activ
     - **`nl`**: the name of the exercise in Dutch
     - **`en`**: the name of the exercise in English
 - **`evaluation`**: the specification of the evaluation procedure
-  - **`handler`** (string, optional): the name of the judge that is used for evaluation. By default, Dodona uses the judge specified for the repository.
+  - **`handler`** (string, optional): the name of the judge that is used for evaluation. By default, Dodona uses the judge specified for the repository. An overview of the available judges can be found [here](/en/references/judges).
   - **`image`** (string, optional): the name of the docker image that is used for evaluation. By default, Dodona uses the image specified by the judge.
   - **`time_limit`** (integer, optional): the time in seconds before the evaluations times out. By default, the limit is 42 seconds.
   - **`memory_limit`** (integer, optional): the amount of memory in bytes that is available for running the evaluation. By default, the limit is 100MB.

--- a/en/references/exercise-directory-structure/README.md
+++ b/en/references/exercise-directory-structure/README.md
@@ -23,7 +23,7 @@ Take a look at the [example exercises repository](https://github.com/dodona-edu/
 Inside the `description` directory, you can specify the following directories:
 - **An optional `media` directory**: this directory contains static files such as images used in the exercise description.
 - **An optional `boilerplate` directory**: this directory contains the files `boilerplate.en`, `boilerplate.nl`, and/or `boilerplate`. The contents of these files are loaded automatically in the submission text area of the users. You can use this to provide some starting code or structure to your students.
-- **An `evaluation` directory**: the content of this directory is made available to the judge and can, for example, contain files containing the test code.
+- **An `evaluation` directory**: the content of this directory is made available to the judge and can, for example, contain files containing the test code. Look at the documentation of the judge you are using to see what files are expected. You can find links to the documentation for each judge [here](/en/references/judges).
 - **An optional `workdir` directory**: The content of this directory is made available when running the judge and can, for example, contain data files needed during execution.
 - **An optional `solution` directory**: Files in this directory will be shown on the exercise info page as sample solutions. Multiple sample solutions are possible, but files with a name starting with *solution* will be sorted first.
 

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -119,7 +119,7 @@ If you want to create your own C# exercises, we recommend you to use the [TESTed
 ## JUnit (Deprecated)
 The JUnit judge is a judge for java8 exercises.
 It is deprecated and should only be used for legacy exercises.
-If you want to create your own Java exercises, we recommend you to use the [JUnit judge](#junit) instead.\
+If you want to create your own Java exercises, we recommend you to use the [Java judge](#java) instead.\
 **Programing languages:** Java\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-java8), [examples](https://github.com/dodona-edu/example-exercises/tree/master/java) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -26,7 +26,7 @@ It uses a simple custom test format, that is indpendent of the programming langu
 
 ## Python
 Python/Pythia is the first judge that was created for Dodona.
-It is a python judge that allows simple input/output tests or more advanced doctests.\
+It is a Python judge that allows simple input/output tests or more advanced doctests.\
 **Programing languages:** Python\
 **Get started** [Documentation](/en/references/python-judge), [examples](https://github.com/dodona-edu/example-exercises/tree/master/python) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -55,6 +55,12 @@ The SQL judge supports both query evaluation (DML) and structural database build
 **Get started** [Documentation](https://github.com/dodona-edu/judge-sql), [examples](https://github.com/dodona-edu/example-exercises/tree/master/sql) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
+## Scheme
+Scheme is a judge that supports the `R5RS` variant of the scheme programming language. It uses a custom testframework [dunit](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/collects/dunit) to define the tests.\
+**Programing languages:** Scheme\
+**Get started** [Documentation](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge), [examples](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/example-exercises) \
+**Created by:** [Mathijs Saey](mailto:scpi@dinf.vub.ac.be)
+
 ## Prolog
 Prolog is a judge that can be used for exercises on the prolog programming language.
 It supports PLUnit, QuickCheck and simple input output tests.\
@@ -67,12 +73,6 @@ Haskell is a judge that uses HUnit to test haskell exercises. \
 **Programing languages:** Haskell\
 **Get started** [Github repo](https://github.com/dodona-edu/judge-haskell), [examples](https://github.com/dodona-edu/example-exercises/tree/master/haskell) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
-
-## Scheme
-Scheme is a judge that can be used for exercises on the scheme programming language.\
-**Programing languages:** Scheme\
-**Get started** Contact the creators to get more info about this judge.\
-**Created by:** [Mathijs Saey](mailto:mathijs.saey@vub.be)
 
 ## HTML
 The HTML judge evaluates both the HTML and CSS code of a student, based on a model solution or a checklist of criteria.\

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -17,6 +17,22 @@ Advanced users can also create their own judge, see [this guide](/en/guides/crea
 
 
 Dodona currently supports the following judges:
+ * [TESTed](/en/references/judges#tested)
+ * [Python](/en/references/judges#python)
+ * [R](/en/references/judges#r)
+ * [JUnit](/en/references/judges#junit)
+ * [C](/en/references/judges#c)
+ * [SQL](/en/references/judges#sql)
+ * [Prolog](/en/references/judges#prolog)
+ * [Haskell](/en/references/judges#haskell)
+ * [Scheme](/en/references/judges#scheme)
+ * [HTML](/en/references/judges#html)
+ * [Turtle](/en/references/judges#turtle)
+ * [Markdown](/en/references/judges#markdown)
+ * [Java](/en/references/judges#java)
+ * [JavaScript](/en/references/judges#javascript)
+ * [Csharp (Deprecated)](/en/references/judges#csharp)
+ * [Bash (Deprecated)](/en/references/judges#bash)
 
 ### TESTed
 TESTED is a whitebox judge that can be used for multiple programming languages.

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -37,8 +37,8 @@ R is a judge that can be used for exercises on the R programming language.\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-r), [examples](https://github.com/dodona-edu/example-exercises/tree/master/R) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-## JUnit 
-JUnit uses the JUnit4 framework to run tests on java exercises.\
+## Java
+The java judge uses the JUnit4 framework to run tests on java exercises.\
 **Programing languages:** Java\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-java), [examples](https://github.com/dodona-edu/judge-java/tree/master/examples) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
@@ -116,8 +116,8 @@ If you want to create your own C# exercises, we recommend you to use the [TESTed
 **Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-## Java (Deprecated)
-The Java judge is a JUnit judge for java8 exercises.
+## JUnit (Deprecated)
+The JUnit judge is a judge for java8 exercises.
 It is deprecated and should only be used for legacy exercises.
 If you want to create your own Java exercises, we recommend you to use the [JUnit judge](#junit) instead.\
 **Programing languages:** Java\

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -1,0 +1,44 @@
+---
+title: Judges
+description: "Overview of all judges available on Dodona"
+---
+
+# Judges
+
+This guide is written for teachers who are creating exercises for Dodona.
+
+Before you create an exercise, you should decide which `judge` you want to use.
+The `judge` is the program that will evaluate the submissions of students.
+It is often written for for one specific programming language, or for a set of programming languages.
+Each `judge` has its own configuration options, we will provide a link to the relevant documentation for each `judge` below.
+These judge specific options should be provided in the `evaluation` directory of the [exercise configuration](/en/references/exercise-directory-structure).
+
+Advanced users can also create their own judge, see [this guide](/en/guides/creating-a-judge/).
+
+
+Dodona currently supports the following judges:
+
+### TESTed
+TESTED is a whitebox judge that can be used for multiple programming languages.
+It uses a simple custom exercise format, that is indpendent of the programming language.\
+**Programing languages:** Bash, C, C#, Haskell, Jave, Javascript, Kotlin, Python\
+**Documentation** [TESTed](/en/tested#designing-exercises-for-dodona)\
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### Python
+Python/Pythia is the first judge that was created for Dodona.
+It is a python judge that allows simple input/output tests or more advanced doctests.\
+**Programing languages:** Python\
+**Documentation** [Python](/en/references/python-judge)\
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### Haskell
+Haskell is a judge that can be used for Haskell exercises.\
+**Programing languages:** Haskell\
+**Documentation** not present\
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+
+
+
+

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -20,23 +20,113 @@ Dodona currently supports the following judges:
 
 ### TESTed
 TESTED is a whitebox judge that can be used for multiple programming languages.
-It uses a simple custom exercise format, that is indpendent of the programming language.\
-**Programing languages:** Bash, C, C#, Haskell, Jave, Javascript, Kotlin, Python\
-**Documentation** [TESTed](/en/tested#designing-exercises-for-dodona)\
+It uses a simple custom test format, that is indpendent of the programming language.\
+**Programing languages:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python\
+**Get started** [Documentation](/en/tested#designing-exercises-for-dodona)\
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Python
 Python/Pythia is the first judge that was created for Dodona.
 It is a python judge that allows simple input/output tests or more advanced doctests.\
 **Programing languages:** Python\
-**Documentation** [Python](/en/references/python-judge)\
+**Get started** [Documentation](/en/references/python-judge)\
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Haskell
-Haskell is a judge that can be used for Haskell exercises.\
+Haskell is a judge that can be used for Haskell exercises.
+It is undocumented.
+If you want to create your own Haskell exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
 **Programing languages:** Haskell\
-**Documentation** not present\
+**Get started** [Github repo](https://github.com/dodona-edu/judge-haskell) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### Bash
+Bash is a judge that can be used for exercises on the bash terminal.
+It is undocumented and has a lot of very usecase specific implementations.
+If you want to create your own bash exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.
+**Programing languages:** Bash\
+**Get started** Contact the creators to get more info about this judge.\
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### JUnit 
+JUnit uses the JUnit4 framework to run tests on java exercises.\
+**Programing languages:** Java\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-java) \
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### Javascript
+Javascript is a judge that can be used for exercises on the javascript programming language.
+It is undocumented and has a lot of very usecase specific implementations.
+If you want to create your own javascript exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
+**Programing languages:** Javascript\
+**Get started** [Github repo](https://github.com/dodona-edu/judge-javascript) \
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### Prolog
+Prolog is a judge that can be used for exercises on the prolog programming language.
+It supports PLUnit, QuickCheck and simple input output tests.\
+**Programing languages:** Prolog\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-prolog) \
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### Csharp (Deprecated)
+The Csharp judge is deprecated and should only be used for legacy exercises.
+If you want to create your own C# exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
+**Programing languages:** C#\
+**Get started** This judge is deprecated.\
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### R
+R is a judge that can be used for exercises on the R programming language.\
+**Programing languages:** R\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-r) \
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### Java (Deprecated)
+The Java judge is a JUnit judge for java8 exercises.
+It is deprecated and should only be used for legacy exercises.
+If you want to create your own Java exercises, we recommend you to use the [JUnit judge](/en/references/judges#junit) instead.\
+**Programing languages:** Java\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-java8) \
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### C
+C is a judge that uses the GTester framework to run tests on C exercises.\
+**Programing languages:** C\
+**Get started** [Documentation](https://github.com/mvdcamme/C-Judge) \
+**Created by:** [Maarten Vandercammen](mailto:mvdcamme@vub.ac.be)
+
+### Scheme
+Scheme is a judge that can be used for exercises on the scheme programming language.\
+**Programing languages:** Scheme\
+**Get started** Contact the creators to get more info about this judge.\
+**Created by:** [Mathijs Saey](mailto:mathijs.saey@vub.be)
+
+### SQL
+The SQL judge supports both query evaluation (DML) and structural database building (DDL).\
+**Programing languages:** SQL\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-sql) \
+**Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+
+### HTML
+The HTML judge evaluates both the HTML and CSS code of a student, based on a model solution or a checklist of criteria.\
+**Programing languages:** HTML, CSS\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-html) \
+**Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+
+### Turtle
+The Turtle judge evaluates the output of a python turtle program. It calculates the similarity between the output of the student and the model solution.\
+**Programing languages:** Python (Turtle)\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-turtle) \
+**Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+
+### Markdown
+The markdown judge is not a real judge as it does not evaluate code.
+It does render the markdown code of a student and can be useful to manually evaluate the output in Dodona.\
+**Programing languages:** Markdown\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-markdown) \
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
 
 
 

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -32,20 +32,10 @@ It is a python judge that allows simple input/output tests or more advanced doct
 **Get started** [Documentation](/en/references/python-judge)\
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### Haskell
-Haskell is a judge that can be used for Haskell exercises.
-It is undocumented.
-If you want to create your own Haskell exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
-**Programing languages:** Haskell\
-**Get started** [Github repo](https://github.com/dodona-edu/judge-haskell) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
-
-### Bash
-Bash is a judge that can be used for exercises on the bash terminal.
-It is undocumented and has a lot of very usecase specific implementations.
-If you want to create your own bash exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.
-**Programing languages:** Bash\
-**Get started** Contact the creators to get more info about this judge.\
+### R
+R is a judge that can be used for exercises on the R programming language.\
+**Programing languages:** R\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-r) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### JUnit 
@@ -54,13 +44,17 @@ JUnit uses the JUnit4 framework to run tests on java exercises.\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-java) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### Javascript
-Javascript is a judge that can be used for exercises on the javascript programming language.
-It is undocumented and has a lot of very usecase specific implementations.
-If you want to create your own javascript exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
-**Programing languages:** Javascript\
-**Get started** [Github repo](https://github.com/dodona-edu/judge-javascript) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+### C
+C is a judge that uses the GTester framework to run tests on C exercises.\
+**Programing languages:** C\
+**Get started** [Documentation](https://github.com/mvdcamme/C-Judge) \
+**Created by:** [Maarten Vandercammen](mailto:mvdcamme@vub.ac.be)
+
+### SQL
+The SQL judge supports both query evaluation (DML) and structural database building (DDL).\
+**Programing languages:** SQL\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-sql) \
+**Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ### Prolog
 Prolog is a judge that can be used for exercises on the prolog programming language.
@@ -69,44 +63,18 @@ It supports PLUnit, QuickCheck and simple input output tests.\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-prolog) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### Csharp (Deprecated)
-The Csharp judge is deprecated and should only be used for legacy exercises.
-If you want to create your own C# exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
-**Programing languages:** C#\
-**Get started** This judge is deprecated.\
+### Haskell
+Haskell is a judge that can be used for Haskell exercises.
+It is currently undocumented.\
+**Programing languages:** Haskell\
+**Get started** [Github repo](https://github.com/dodona-edu/judge-haskell) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
-
-### R
-R is a judge that can be used for exercises on the R programming language.\
-**Programing languages:** R\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-r) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
-
-### Java (Deprecated)
-The Java judge is a JUnit judge for java8 exercises.
-It is deprecated and should only be used for legacy exercises.
-If you want to create your own Java exercises, we recommend you to use the [JUnit judge](/en/references/judges#junit) instead.\
-**Programing languages:** Java\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-java8) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
-
-### C
-C is a judge that uses the GTester framework to run tests on C exercises.\
-**Programing languages:** C\
-**Get started** [Documentation](https://github.com/mvdcamme/C-Judge) \
-**Created by:** [Maarten Vandercammen](mailto:mvdcamme@vub.ac.be)
 
 ### Scheme
 Scheme is a judge that can be used for exercises on the scheme programming language.\
 **Programing languages:** Scheme\
 **Get started** Contact the creators to get more info about this judge.\
 **Created by:** [Mathijs Saey](mailto:mathijs.saey@vub.be)
-
-### SQL
-The SQL judge supports both query evaluation (DML) and structural database building (DDL).\
-**Programing languages:** SQL\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-sql) \
-**Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ### HTML
 The HTML judge evaluates both the HTML and CSS code of a student, based on a model solution or a checklist of criteria.\
@@ -125,6 +93,37 @@ The markdown judge is not a real judge as it does not evaluate code.
 It does render the markdown code of a student and can be useful to manually evaluate the output in Dodona.\
 **Programing languages:** Markdown\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-markdown) \
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### Javascript
+Javascript is a judge that can be used for exercises on the javascript programming language.
+It is undocumented and has a lot of very usecase specific implementations.
+If you want to create your own javascript exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
+**Programing languages:** Javascript\
+**Get started** [Github repo](https://github.com/dodona-edu/judge-javascript) \
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### Bash
+Bash is a judge that can be used for exercises on the bash terminal.
+It is undocumented and has a lot of very usecase specific implementations.
+If you want to create your own bash exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.
+**Programing languages:** Bash\
+**Get started** Contact the creators to get more info about this judge.\
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### Csharp (Deprecated)
+The Csharp judge is deprecated and should only be used for legacy exercises.
+If you want to create your own C# exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
+**Programing languages:** C#\
+**Get started** This judge is deprecated.\
+**Created by:** [Team dodona](mailto:dodona@ugent.be)
+
+### Java (Deprecated)
+The Java judge is a JUnit judge for java8 exercises.
+It is deprecated and should only be used for legacy exercises.
+If you want to create your own Java exercises, we recommend you to use the [JUnit judge](/en/references/judges#junit) instead.\
+**Programing languages:** Java\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-java8) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -81,7 +81,7 @@ The HTML judge evaluates both the HTML and CSS code of a student, based on a mod
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ## Turtle
-The Turtle judge evaluates the output of a python turtle program. It calculates the similarity between the output of the student and the model solution.\
+The Turtle judge evaluates the output of a Python turtle program. It calculates the similarity between the output of the student and the model solution.\
 **Programing languages:** Python (Turtle)\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-turtle) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -3,8 +3,6 @@ title: Judges
 description: "Overview of all judges available on Dodona"
 ---
 
-# Judges
-
 This guide is written for teachers who are creating exercises for Dodona.
 
 Before you create an exercise, you should decide which `judge` you want to use.
@@ -38,52 +36,51 @@ Dodona currently supports the following judges:
 TESTED is a whitebox judge that can be used for multiple programming languages.
 It uses a simple custom test format, that is indpendent of the programming language.\
 **Programing languages:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python\
-**Get started** [Documentation](/en/tested#designing-exercises-for-dodona)\
+**Get started** [Documentation](/en/tested#designing-exercises-for-dodona), [examples](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Python
 Python/Pythia is the first judge that was created for Dodona.
 It is a python judge that allows simple input/output tests or more advanced doctests.\
 **Programing languages:** Python\
-**Get started** [Documentation](/en/references/python-judge)\
+**Get started** [Documentation](/en/references/python-judge), [examples](https://github.com/dodona-edu/example-exercises/tree/master/python) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### R
 R is a judge that can be used for exercises on the R programming language.\
 **Programing languages:** R\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-r) \
+**Get started** [Documentation](https://github.com/dodona-edu/judge-r), [examples](https://github.com/dodona-edu/example-exercises/tree/master/R) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### JUnit 
 JUnit uses the JUnit4 framework to run tests on java exercises.\
 **Programing languages:** Java\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-java) \
+**Get started** [Documentation](https://github.com/dodona-edu/judge-java), [examples](https://github.com/dodona-edu/judge-java/tree/master/examples) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### C
 C is a judge that uses the GTester framework to run tests on C exercises.\
 **Programing languages:** C\
-**Get started** [Documentation](https://github.com/mvdcamme/C-Judge) \
+**Get started** [Documentation](https://github.com/mvdcamme/C-Judge), [examples](https://github.com/mvdcamme/C-Judge/tree/master/example_exercises) \
 **Created by:** [Maarten Vandercammen](mailto:mvdcamme@vub.ac.be)
 
 ### SQL
 The SQL judge supports both query evaluation (DML) and structural database building (DDL).\
 **Programing languages:** SQL\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-sql) \
+**Get started** [Documentation](https://github.com/dodona-edu/judge-sql), [examples](https://github.com/dodona-edu/example-exercises/tree/master/sql) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ### Prolog
 Prolog is a judge that can be used for exercises on the prolog programming language.
 It supports PLUnit, QuickCheck and simple input output tests.\
 **Programing languages:** Prolog\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-prolog) \
+**Get started** [Documentation](https://github.com/dodona-edu/judge-prolog), [examples](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Haskell
-Haskell is a judge that can be used for Haskell exercises.
-It is currently undocumented.\
+Haskell is a judge that uses HUnit to test haskell exercises. \
 **Programing languages:** Haskell\
-**Get started** [Github repo](https://github.com/dodona-edu/judge-haskell) \
+**Get started** [Github repo](https://github.com/dodona-edu/judge-haskell), [examples](https://github.com/dodona-edu/example-exercises/tree/master/haskell) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Scheme
@@ -95,7 +92,7 @@ Scheme is a judge that can be used for exercises on the scheme programming langu
 ### HTML
 The HTML judge evaluates both the HTML and CSS code of a student, based on a model solution or a checklist of criteria.\
 **Programing languages:** HTML, CSS\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-html) \
+**Get started** [Documentation](https://github.com/dodona-edu/judge-html), [examples](https://github.com/dodona-edu/example-exercises/tree/master/html) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ### Turtle
@@ -116,7 +113,7 @@ Javascript is a judge that can be used for exercises on the javascript programmi
 It is undocumented and has a lot of very usecase specific implementations.
 If you want to create your own javascript exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
 **Programing languages:** Javascript\
-**Get started** [Github repo](https://github.com/dodona-edu/judge-javascript) \
+**Get started** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Bash
@@ -124,14 +121,14 @@ Bash is a judge that can be used for exercises on the bash terminal.
 It is undocumented and has a lot of very usecase specific implementations.
 If you want to create your own bash exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.
 **Programing languages:** Bash\
-**Get started** Contact the creators to get more info about this judge.\
+**Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), contact the creators to get more info about this judge. \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Csharp (Deprecated)
 The Csharp judge is deprecated and should only be used for legacy exercises.
 If you want to create your own C# exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
 **Programing languages:** C#\
-**Get started** This judge is deprecated.\
+**Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Java (Deprecated)
@@ -139,7 +136,7 @@ The Java judge is a JUnit judge for java8 exercises.
 It is deprecated and should only be used for legacy exercises.
 If you want to create your own Java exercises, we recommend you to use the [JUnit judge](/en/references/judges#junit) instead.\
 **Programing languages:** Java\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-java8) \
+**Get started** [Documentation](https://github.com/dodona-edu/judge-java8), [examples](https://github.com/dodona-edu/example-exercises/tree/master/java) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -22,76 +22,76 @@ TESTed is a whitebox judge that can be used for multiple programming languages.
 It uses a simple custom test format, that is independent of the programming language of the exercise.\
 **Programming languages:** Bash, C, C#, Haskell, Java, JavaScript, Kotlin, Python\
 **Get started** [Documentation](/en/tested#designing-exercises-for-dodona), [examples](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Python
 Python/Pythia is the first judge that was created for Dodona.
 It is a Python judge that allows simple input/output tests or more advanced doctests.\
 **Programing languages:** Python\
 **Get started** [Documentation](/en/references/python-judge), [examples](https://github.com/dodona-edu/example-exercises/tree/master/python) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## R
 R is a judge that can be used for exercises on the R programming language.\
-**Programing languages:** R\
+**Programming languages:** R\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-r), [examples](https://github.com/dodona-edu/example-exercises/tree/master/R) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Java
 The java judge uses the JUnit4 framework to run tests on Java exercises.\
-**Programing languages:** Java\
+**Programming languages:** Java\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-java), [examples](https://github.com/dodona-edu/judge-java/tree/master/examples) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## C
 C is a judge that uses the GTester framework to run tests on C exercises.\
-**Programing languages:** C\
+**Programming languages:** C\
 **Get started** [Documentation](https://github.com/mvdcamme/C-Judge), [examples](https://github.com/mvdcamme/C-Judge/tree/master/example_exercises) \
 **Created by:** [Maarten Vandercammen](mailto:mvdcamme@vub.ac.be)
 
 ## SQL
 The SQL judge supports both query evaluation (DML) and structural database building (DDL).\
-**Programing languages:** SQL\
+**Programming languages:** SQL\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-sql), [examples](https://github.com/dodona-edu/example-exercises/tree/master/sql) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ## Scheme
 Scheme is a judge that supports the `R5RS` variant of the scheme programming language. It uses a custom testframework [dunit](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/collects/dunit) to define the tests.\
-**Programing languages:** Scheme\
+**Programming languages:** Scheme\
 **Get started** [Documentation](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge), [examples](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/example-exercises) \
 **Created by:** [Mathijs Saey](mailto:scpi@dinf.vub.ac.be)
 
 ## Prolog
 Prolog is a judge that can be used for exercises on the Prolog programming language.
 It supports PLUnit, QuickCheck and simple input output tests.\
-**Programing languages:** Prolog\
+**Programming languages:** Prolog\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-prolog), [examples](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Haskell
 Haskell is a judge that uses HUnit to test Haskell exercises. \
-**Programing languages:** Haskell\
+**Programming languages:** Haskell\
 **Get started** [Github repo](https://github.com/dodona-edu/judge-haskell), [examples](https://github.com/dodona-edu/example-exercises/tree/master/haskell) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## HTML
 The HTML judge evaluates both the HTML and CSS code of a student, based on a model solution or a checklist of criteria.\
-**Programing languages:** HTML, CSS\
+**Programming languages:** HTML, CSS\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-html), [examples](https://github.com/dodona-edu/example-exercises/tree/master/html) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ## Turtle
 The Turtle judge evaluates the output of a Python Turtle program. It calculates the similarity between the output of the student and the model solution.\
-**Programing languages:** Python (Turtle)\
+**Programming languages:** Python (Turtle)\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-turtle) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ## Markdown
 The markdown judge is not a real judge as it does not evaluate code.
 It does render the Markdown code of a student and can be useful to manually evaluate the output in Dodona.\
-**Programing languages:** Markdown\
+**Programming languages:** Markdown\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-markdown) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Javascript
 Javascript is a judge that can be used for exercises on the JavaScript programming language.
@@ -99,30 +99,30 @@ It is undocumented and has a lot of very usecase specific implementations.
 If you want to create your own JavaScript exercises, we recommend you to use the [TESTed judge](#tested) instead.\
 **Programming languages:** JavaScript\
 **Get started** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Bash
 Bash is a judge that can be used for exercises on the bash terminal.
 It is undocumented and has a lot of very usecase specific implementations.
 If you want to create your own Bash exercises, we recommend you to use the [TESTed judge](#tested) instead.
-**Programing languages:** Bash\
+**Programming languages:** Bash\
 **Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), contact the creators to get more info about this judge. \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Csharp (Deprecated)
 The Csharp judge is deprecated and should only be used for legacy exercises.
 If you want to create your own C# exercises, we recommend you to use the [TESTed judge](#tested) instead.\
-**Programing languages:** C#\
+**Programming languages:** C#\
 **Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## JUnit (Deprecated)
 The JUnit judge is a judge for Java 8 exercises.
 It is deprecated and should only be used for legacy exercises.
 If you want to create your own Java exercises, we recommend you to use the [Java judge](#java) instead.\
-**Programing languages:** Java\
+**Programming languages:** Java\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-java8), [examples](https://github.com/dodona-edu/example-exercises/tree/master/java) \
-**Created by:** [Team dodona](mailto:dodona@ugent.be)
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 
 

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -11,7 +11,7 @@ It is often written for for one specific programming language, or for a set of p
 Each `judge` has its own configuration options, we will provide a link to the relevant documentation for each `judge` below.
 These judge specific options should be provided in the `evaluation` directory of the [exercise configuration](/en/references/exercise-directory-structure).
 
-Advanced users can also create their own judge, see [this guide](/en/guides/creating-a-judge/).
+Advanced users can also create their own judge, see [this guide](/en/guides/creating-a-judge).
 
 
 Dodona currently supports the following judges:
@@ -36,7 +36,7 @@ Dodona currently supports the following judges:
 TESTED is a whitebox judge that can be used for multiple programming languages.
 It uses a simple custom test format, that is indpendent of the programming language.\
 **Programing languages:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python\
-**Get started** [Documentation](/en/tested#designing-exercises-for-dodona), [examples](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
+**Get started** [Documentation](/en/references/tested#designing-exercises-for-dodona), [examples](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Python

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -7,20 +7,20 @@ description: "Overview of all judges available on Dodona"
 
 This guide is written for teachers who are creating exercises for Dodona.
 
-Before you create an exercise, you should decide which `judge` you want to use.
-The `judge` is the program that will evaluate the submissions of students.
-It is often written for one specific programming language, or for a set of programming languages.
-Each `judge` has its own configuration options, we will provide a link to the relevant documentation for each `judge` below.
-These judge specific options should be provided in the `evaluation` directory of the [exercise configuration](/en/references/exercise-directory-structure).
+Before you create an exercise, you should decide which _judge_ you want to use.
+A judge is the program that will evaluate the submissions of students.
+It is often written for one specific programming language, but supporting a set of programming languages is also possible.
+Each judge has its own configuration options, we will provide a link to the relevant documentation for each judge below.
+These judge-specific options should be provided in the `evaluation` directory of the [exercise configuration](/en/references/exercise-directory-structure).
 
 Advanced users can also create their own judge, see [this guide](/en/guides/creating-a-judge).
 
 Dodona currently supports the following judges:
 
 ## TESTed
-TESTED is a whitebox judge that can be used for multiple programming languages.
-It uses a simple custom test format, that is indpendent of the programming language.\
-**Programing languages:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python\
+TESTed is a whitebox judge that can be used for multiple programming languages.
+It uses a simple custom test format, that is independent of the programming language of the exercise.\
+**Programming languages:** Bash, C, C#, Haskell, Java, JavaScript, Kotlin, Python\
 **Get started** [Documentation](/en/tested#designing-exercises-for-dodona), [examples](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
@@ -62,7 +62,7 @@ Scheme is a judge that supports the `R5RS` variant of the scheme programming lan
 **Created by:** [Mathijs Saey](mailto:scpi@dinf.vub.ac.be)
 
 ## Prolog
-Prolog is a judge that can be used for exercises on the prolog programming language.
+Prolog is a judge that can be used for exercises on the Prolog programming language.
 It supports PLUnit, QuickCheck and simple input output tests.\
 **Programing languages:** Prolog\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-prolog), [examples](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
@@ -81,14 +81,14 @@ The HTML judge evaluates both the HTML and CSS code of a student, based on a mod
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ## Turtle
-The Turtle judge evaluates the output of a Python turtle program. It calculates the similarity between the output of the student and the model solution.\
+The Turtle judge evaluates the output of a Python Turtle program. It calculates the similarity between the output of the student and the model solution.\
 **Programing languages:** Python (Turtle)\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-turtle) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ## Markdown
 The markdown judge is not a real judge as it does not evaluate code.
-It does render the markdown code of a student and can be useful to manually evaluate the output in Dodona.\
+It does render the Markdown code of a student and can be useful to manually evaluate the output in Dodona.\
 **Programing languages:** Markdown\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-markdown) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
@@ -96,15 +96,15 @@ It does render the markdown code of a student and can be useful to manually eval
 ## Javascript
 Javascript is a judge that can be used for exercises on the JavaScript programming language.
 It is undocumented and has a lot of very usecase specific implementations.
-If you want to create your own javascript exercises, we recommend you to use the [TESTed judge](#tested) instead.\
-**Programing languages:** Javascript\
+If you want to create your own JavaScript exercises, we recommend you to use the [TESTed judge](#tested) instead.\
+**Programming languages:** JavaScript\
 **Get started** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ## Bash
 Bash is a judge that can be used for exercises on the bash terminal.
 It is undocumented and has a lot of very usecase specific implementations.
-If you want to create your own bash exercises, we recommend you to use the [TESTed judge](#tested) instead.
+If you want to create your own Bash exercises, we recommend you to use the [TESTed judge](#tested) instead.
 **Programing languages:** Bash\
 **Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), contact the creators to get more info about this judge. \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -38,7 +38,7 @@ R is a judge that can be used for exercises on the R programming language.\
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ## Java
-The java judge uses the JUnit4 framework to run tests on java exercises.\
+The java judge uses the JUnit4 framework to run tests on Java exercises.\
 **Programing languages:** Java\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-java), [examples](https://github.com/dodona-edu/judge-java/tree/master/examples) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
@@ -69,7 +69,7 @@ It supports PLUnit, QuickCheck and simple input output tests.\
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ## Haskell
-Haskell is a judge that uses HUnit to test haskell exercises. \
+Haskell is a judge that uses HUnit to test Haskell exercises. \
 **Programing languages:** Haskell\
 **Get started** [Github repo](https://github.com/dodona-edu/judge-haskell), [examples](https://github.com/dodona-edu/example-exercises/tree/master/haskell) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
@@ -94,7 +94,7 @@ It does render the markdown code of a student and can be useful to manually eval
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ## Javascript
-Javascript is a judge that can be used for exercises on the javascript programming language.
+Javascript is a judge that can be used for exercises on the JavaScript programming language.
 It is undocumented and has a lot of very usecase specific implementations.
 If you want to create your own javascript exercises, we recommend you to use the [TESTed judge](#tested) instead.\
 **Programing languages:** Javascript\
@@ -117,7 +117,7 @@ If you want to create your own C# exercises, we recommend you to use the [TESTed
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ## JUnit (Deprecated)
-The JUnit judge is a judge for java8 exercises.
+The JUnit judge is a judge for Java 8 exercises.
 It is deprecated and should only be used for legacy exercises.
 If you want to create your own Java exercises, we recommend you to use the [Java judge](#java) instead.\
 **Programing languages:** Java\

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -27,7 +27,7 @@ It uses a simple custom test format, that is independent of the programming lang
 ## Python
 Python/Pythia is the first judge that was created for Dodona.
 It is a Python judge that allows simple input/output tests or more advanced doctests.\
-**Programing languages:** Python\
+**Programming languages:** Python\
 **Get started** [Documentation](/en/references/python-judge), [examples](https://github.com/dodona-edu/example-exercises/tree/master/python) \
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)
 

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -15,28 +15,28 @@ Advanced users can also create their own judge, see [this guide](/en/guides/crea
 
 
 Dodona currently supports the following judges:
- * [TESTed](/en/references/judges#tested)
- * [Python](/en/references/judges#python)
- * [R](/en/references/judges#r)
- * [JUnit](/en/references/judges#junit)
- * [C](/en/references/judges#c)
- * [SQL](/en/references/judges#sql)
- * [Prolog](/en/references/judges#prolog)
- * [Haskell](/en/references/judges#haskell)
- * [Scheme](/en/references/judges#scheme)
- * [HTML](/en/references/judges#html)
- * [Turtle](/en/references/judges#turtle)
- * [Markdown](/en/references/judges#markdown)
- * [Java](/en/references/judges#java)
- * [JavaScript](/en/references/judges#javascript)
- * [Csharp (Deprecated)](/en/references/judges#csharp)
- * [Bash (Deprecated)](/en/references/judges#bash)
+ * [TESTed](#tested)
+ * [Python](#python)
+ * [R](#r)
+ * [JUnit](#junit)
+ * [C](#c)
+ * [SQL](#sql)
+ * [Prolog](#prolog)
+ * [Haskell](#haskell)
+ * [Scheme](#scheme)
+ * [HTML](#html)
+ * [Turtle](#turtle)
+ * [Markdown](#markdown)
+ * [JavaScript](#javascript)
+ * [Bash](#bash)
+ * [Csharp (Deprecated)](#csharp-(deprecated))
+ * [Java (Deprecated)](#java-(deprecated)))
 
 ### TESTed
 TESTED is a whitebox judge that can be used for multiple programming languages.
 It uses a simple custom test format, that is indpendent of the programming language.\
 **Programing languages:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python\
-**Get started** [Documentation](/en/references/tested#designing-exercises-for-dodona), [examples](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
+**Get started** [Documentation](/en/tested#designing-exercises-for-dodona), [examples](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Python
@@ -111,7 +111,7 @@ It does render the markdown code of a student and can be useful to manually eval
 ### Javascript
 Javascript is a judge that can be used for exercises on the javascript programming language.
 It is undocumented and has a lot of very usecase specific implementations.
-If you want to create your own javascript exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
+If you want to create your own javascript exercises, we recommend you to use the [TESTed judge](#tested) instead.\
 **Programing languages:** Javascript\
 **Get started** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
@@ -119,14 +119,14 @@ If you want to create your own javascript exercises, we recommend you to use the
 ### Bash
 Bash is a judge that can be used for exercises on the bash terminal.
 It is undocumented and has a lot of very usecase specific implementations.
-If you want to create your own bash exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.
+If you want to create your own bash exercises, we recommend you to use the [TESTed judge](#tested) instead.
 **Programing languages:** Bash\
 **Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), contact the creators to get more info about this judge. \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Csharp (Deprecated)
 The Csharp judge is deprecated and should only be used for legacy exercises.
-If you want to create your own C# exercises, we recommend you to use the [TESTed judge](/en/references/judges#tested) instead.\
+If you want to create your own C# exercises, we recommend you to use the [TESTed judge](#tested) instead.\
 **Programing languages:** C#\
 **Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
@@ -134,7 +134,7 @@ If you want to create your own C# exercises, we recommend you to use the [TESTed
 ### Java (Deprecated)
 The Java judge is a JUnit judge for java8 exercises.
 It is deprecated and should only be used for legacy exercises.
-If you want to create your own Java exercises, we recommend you to use the [JUnit judge](/en/references/judges#junit) instead.\
+If you want to create your own Java exercises, we recommend you to use the [JUnit judge](#junit) instead.\
 **Programing languages:** Java\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-java8), [examples](https://github.com/dodona-edu/example-exercises/tree/master/java) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)

--- a/en/references/judges/README.md
+++ b/en/references/judges/README.md
@@ -3,112 +3,97 @@ title: Judges
 description: "Overview of all judges available on Dodona"
 ---
 
+# Judges
+
 This guide is written for teachers who are creating exercises for Dodona.
 
 Before you create an exercise, you should decide which `judge` you want to use.
 The `judge` is the program that will evaluate the submissions of students.
-It is often written for for one specific programming language, or for a set of programming languages.
+It is often written for one specific programming language, or for a set of programming languages.
 Each `judge` has its own configuration options, we will provide a link to the relevant documentation for each `judge` below.
 These judge specific options should be provided in the `evaluation` directory of the [exercise configuration](/en/references/exercise-directory-structure).
 
 Advanced users can also create their own judge, see [this guide](/en/guides/creating-a-judge).
 
-
 Dodona currently supports the following judges:
- * [TESTed](#tested)
- * [Python](#python)
- * [R](#r)
- * [JUnit](#junit)
- * [C](#c)
- * [SQL](#sql)
- * [Prolog](#prolog)
- * [Haskell](#haskell)
- * [Scheme](#scheme)
- * [HTML](#html)
- * [Turtle](#turtle)
- * [Markdown](#markdown)
- * [JavaScript](#javascript)
- * [Bash](#bash)
- * [Csharp (Deprecated)](#csharp-(deprecated))
- * [Java (Deprecated)](#java-(deprecated)))
 
-### TESTed
+## TESTed
 TESTED is a whitebox judge that can be used for multiple programming languages.
 It uses a simple custom test format, that is indpendent of the programming language.\
 **Programing languages:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python\
 **Get started** [Documentation](/en/tested#designing-exercises-for-dodona), [examples](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### Python
+## Python
 Python/Pythia is the first judge that was created for Dodona.
 It is a python judge that allows simple input/output tests or more advanced doctests.\
 **Programing languages:** Python\
 **Get started** [Documentation](/en/references/python-judge), [examples](https://github.com/dodona-edu/example-exercises/tree/master/python) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### R
+## R
 R is a judge that can be used for exercises on the R programming language.\
 **Programing languages:** R\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-r), [examples](https://github.com/dodona-edu/example-exercises/tree/master/R) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### JUnit 
+## JUnit 
 JUnit uses the JUnit4 framework to run tests on java exercises.\
 **Programing languages:** Java\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-java), [examples](https://github.com/dodona-edu/judge-java/tree/master/examples) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### C
+## C
 C is a judge that uses the GTester framework to run tests on C exercises.\
 **Programing languages:** C\
 **Get started** [Documentation](https://github.com/mvdcamme/C-Judge), [examples](https://github.com/mvdcamme/C-Judge/tree/master/example_exercises) \
 **Created by:** [Maarten Vandercammen](mailto:mvdcamme@vub.ac.be)
 
-### SQL
+## SQL
 The SQL judge supports both query evaluation (DML) and structural database building (DDL).\
 **Programing languages:** SQL\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-sql), [examples](https://github.com/dodona-edu/example-exercises/tree/master/sql) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
-### Prolog
+## Prolog
 Prolog is a judge that can be used for exercises on the prolog programming language.
 It supports PLUnit, QuickCheck and simple input output tests.\
 **Programing languages:** Prolog\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-prolog), [examples](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### Haskell
+## Haskell
 Haskell is a judge that uses HUnit to test haskell exercises. \
 **Programing languages:** Haskell\
 **Get started** [Github repo](https://github.com/dodona-edu/judge-haskell), [examples](https://github.com/dodona-edu/example-exercises/tree/master/haskell) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### Scheme
+## Scheme
 Scheme is a judge that can be used for exercises on the scheme programming language.\
 **Programing languages:** Scheme\
 **Get started** Contact the creators to get more info about this judge.\
 **Created by:** [Mathijs Saey](mailto:mathijs.saey@vub.be)
 
-### HTML
+## HTML
 The HTML judge evaluates both the HTML and CSS code of a student, based on a model solution or a checklist of criteria.\
 **Programing languages:** HTML, CSS\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-html), [examples](https://github.com/dodona-edu/example-exercises/tree/master/html) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
-### Turtle
+## Turtle
 The Turtle judge evaluates the output of a python turtle program. It calculates the similarity between the output of the student and the model solution.\
 **Programing languages:** Python (Turtle)\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-turtle) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
-### Markdown
+## Markdown
 The markdown judge is not a real judge as it does not evaluate code.
 It does render the markdown code of a student and can be useful to manually evaluate the output in Dodona.\
 **Programing languages:** Markdown\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-markdown) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### Javascript
+## Javascript
 Javascript is a judge that can be used for exercises on the javascript programming language.
 It is undocumented and has a lot of very usecase specific implementations.
 If you want to create your own javascript exercises, we recommend you to use the [TESTed judge](#tested) instead.\
@@ -116,7 +101,7 @@ If you want to create your own javascript exercises, we recommend you to use the
 **Get started** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### Bash
+## Bash
 Bash is a judge that can be used for exercises on the bash terminal.
 It is undocumented and has a lot of very usecase specific implementations.
 If you want to create your own bash exercises, we recommend you to use the [TESTed judge](#tested) instead.
@@ -124,14 +109,14 @@ If you want to create your own bash exercises, we recommend you to use the [TEST
 **Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), contact the creators to get more info about this judge. \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### Csharp (Deprecated)
+## Csharp (Deprecated)
 The Csharp judge is deprecated and should only be used for legacy exercises.
 If you want to create your own C# exercises, we recommend you to use the [TESTed judge](#tested) instead.\
 **Programing languages:** C#\
 **Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
 **Created by:** [Team dodona](mailto:dodona@ugent.be)
 
-### Java (Deprecated)
+## Java (Deprecated)
 The Java judge is a JUnit judge for java8 exercises.
 It is deprecated and should only be used for legacy exercises.
 If you want to create your own Java exercises, we recommend you to use the [JUnit judge](#junit) instead.\

--- a/nl/guides/creating-a-judge/README.md
+++ b/nl/guides/creating-a-judge/README.md
@@ -8,6 +8,8 @@ description: "Tutorial: creating a judge"
 This is an advanced guide aimed at developers. You will probably not need the info on this page. If you plan to create a judge, please contact us at <a href="mailto:dodona@ugent.be">dodona@ugent.be</a>.
 :::
 
+Before you create your own judge, please check if there is no [existing judge](nl/references/judges) that can be used for your exercises.
+
 For each judge in Dodona, there is one git repository. This git repository requires a [predefined structure](#_2-repository-structure) and [interface](#_3-judge-interface) to fit into Dodona. Once created, a judge should be [added to Dodona](#_1-adding-a-judge), so it can be used for exercises.
 
 ## 1. Adding a Judge

--- a/nl/guides/creating-a-judge/README.md
+++ b/nl/guides/creating-a-judge/README.md
@@ -8,7 +8,7 @@ description: "Tutorial: creating a judge"
 This is an advanced guide aimed at developers. You will probably not need the info on this page. If you plan to create a judge, please contact us at <a href="mailto:dodona@ugent.be">dodona@ugent.be</a>.
 :::
 
-Before you create your own judge, please check if there is no [existing judge](nl/references/judges) that can be used for your exercises.
+Before you create your own judge, please check if there is no [existing judge](/nl/references/judges) that can be used for your exercises.
 
 For each judge in Dodona, there is one git repository. This git repository requires a [predefined structure](#_2-repository-structure) and [interface](#_3-judge-interface) to fit into Dodona. Once created, a judge should be [added to Dodona](#_1-adding-a-judge), so it can be used for exercises.
 

--- a/nl/guides/teachers/new-exercise-repo/README.md
+++ b/nl/guides/teachers/new-exercise-repo/README.md
@@ -43,5 +43,5 @@ Deze URL moet je vervolgens toevoegen aan GitHub. Dit doe je door op GitHub naar
 
 Je bent nu helemaal klaar om oefeningen en lesmateriaal toe te voegen aan je repository. Als alles goed gaat, dan zouden ze automatisch moeten verschijnen op Dodona.
 
-Voor meer informatie over het maken van oefeningen in je repository, bekijk de [repository directory structure](/en/references/repository-directory-structure) referentie.
-Het specifieke formaat van de tests voor je oefeningen hangt af van je gekozen judge. Je vindt een overzicht van alle ondersteunde judges, met links naar hun documentatie, op de [judge overview](/en/references/judge/).
+Voor meer informatie over het maken van oefeningen in je repository, bekijk de [repository directory structure](/nl/references/repository-directory-structure) referentie.
+Het specifieke formaat van de tests voor je oefeningen hangt af van je gekozen judge. Je vindt een overzicht van alle ondersteunde judges, met links naar hun documentatie, op de [judge overview](/nl/references/judges).

--- a/nl/guides/teachers/new-exercise-repo/README.md
+++ b/nl/guides/teachers/new-exercise-repo/README.md
@@ -13,7 +13,7 @@ Een eerste stap is om een git repository aan te maken. Je kan dit eenvoudig doen
 
 ## 2. Je repository aan Dodona toevoegen
 
-Als je lesgeversrechten op Dodona hebt, dan verschijnt in de linker navigatiebalk een link `Repositories` die je naar een [overzicht van alle repositories op Dodona](https://dodona.ugent.be/nl/repositories/) brengt. Om een nieuwe repository toe te voegen, klik je op de grote plus-knop bovenaan de pagina.
+Als je lesgeversrechten op Dodona hebt, dan verschijnt in de linker navigatiebalk een link `Repositories` die je naar een [overzicht van jouw repositories op Dodona](https://dodona.ugent.be/nl/repositories/) brengt. Om een nieuwe repository toe te voegen, klik je op de grote plus-knop bovenaan de pagina.
 
 ![repository toevoegen](./add-repository.png)
 
@@ -42,3 +42,6 @@ Deze URL moet je vervolgens toevoegen aan GitHub. Dit doe je door op GitHub naar
 ## 4. Lesmateriaal aanmaken
 
 Je bent nu helemaal klaar om oefeningen en lesmateriaal toe te voegen aan je repository. Als alles goed gaat, dan zouden ze automatisch moeten verschijnen op Dodona.
+
+Voor meer informatie over het maken van oefeningen in je repository, bekijk de [repository directory structure](/en/references/repository-directory-structure) referentie.
+Het specifieke formaat van de tests voor je oefeningen hangt af van je gekozen judge. Je vindt een overzicht van alle ondersteunde judges, met links naar hun documentatie, op de [judge overview](/en/references/judge/).

--- a/nl/references/README.md
+++ b/nl/references/README.md
@@ -11,3 +11,4 @@ Hier vind je up-to-date beschrijvingen van de Dodona configuratiebestanden en ma
 * [Oefeningconfiguratie](exercise-config)
 * [Oefeningmap-structuur](exercise-directory-structure)
 * [Python judge](python-judge)
+* [Judges](judges)

--- a/nl/references/exercise-config/README.md
+++ b/nl/references/exercise-config/README.md
@@ -10,7 +10,7 @@ Dodona laat toe om de configuratie van een **oefening** of een **leesactiviteit*
 ## Configuratiebestandsstructuur voor oefeningen
 
 - **`type`**: Moet ingesteld worden op `exercise` voor oefeningen. De standaardwaarde indien afwezig is `exercise`.
-- **`programming_language`** (string): de programmeertaal van de oefening, wordt gebruikt voor *syntax highlighting* en om de juiste bestandsextensie te bepalen
+- **`programming_language`** (string): de programmeertaal van de oefening, wordt gebruikt voor *syntax highlighting* en om de juiste bestandsextensie te bepalen. Een overzicht van de mogelijke programmeertalen vind je [hier](https://dodona.ugent.be/nl/programming_languages/).
 - **`access`** (`public` of `private`): bepaalt wie deze oefening kan gebruiken
   - **`public`**: elke lesgever op Dodona kan deze oefening gebruiker
   - **`private`**: enkel lesgevers met expliciete toestemming mogen deze oefening gebruiken
@@ -19,7 +19,7 @@ Dodona laat toe om de configuratie van een **oefening** of een **leesactiviteit*
     - **`nl`**: de naam van de oefening in het Nederlands
     - `en`: de naam van de oefening in het Engels
 - **`evaluation`**: de specificatie van de evaluatieprocedure
-  - **`handler`** (string, optioneel): de naam van de judge die gebruikt wordt voor de evaluatie. Standaard gebruik Dodona de judge die ingesteld is voor de repository.
+  - **`handler`** (string, optioneel): de naam van de judge die gebruikt wordt voor de evaluatie. Standaard gebruik Dodona de judge die ingesteld is voor de repository. Een overzicht van de mogelijke judges vind je [hier](/nl/references/judges).
   - **`image`** (string, optioneel): de naam van de docker image die gebruikt wordt voor de evaluatie. Standaard gebruikt Dodona de image die ingesteld is voor de judge.
   - **`time_limit`** (integer, optioneel): de tijd in seconden waarna de evaluatie van een oefening stopgezet wordt. Standaard is dit 42 seconden
   - **`memory_limit`** (integer, optioneel): de hoeveelheid geheugen in bytes die gebruikt kan worden bij het uitvoeren van de evaluatie. Standaard is dit ingesteld op 100M.

--- a/nl/references/exercise-directory-structure/README.md
+++ b/nl/references/exercise-directory-structure/README.md
@@ -24,7 +24,7 @@ Neem een kijkje in de [voorbeeldoefeningenrepository](https://github.com/dodona-
 Binnenin de `description`-map kan je volgende mappen specifiëren:
 - **Een optionele `media`-map**: deze map bevat statische bestanden zoals afbeeldingen die gebruikt worden in de oefeningbeschrijving.
 - **Een optionele `boilerplate`-map**: deze map bevat de bestanden `boilerplate.en`, `boilerplate.nl`, en/of `boilerplate`. De inhoud van deze bestanden worden automatisch ingeladen in het inzendingstekstveld van de gebruikers. Je kan deze bestanden gebruiken om startcode of structuur te voorzien voor de studenten.
-- **Een `evaluation`-map**: de inhoud van deze map wordt beschikbaar gesteld voor de judge en kan bijvoorbeeld bestanden met de testcode bevatten. Kijk in de documentatie van de judge die u gebruikt om te zien welke bestanden worden verwacht. U vindt links naar de documentatie voor elke judge [hier](/nl/references/judges).
+- **Een `evaluation`-map**: de inhoud van deze map wordt beschikbaar gesteld voor de judge en kan bijvoorbeeld bestanden met de testcode bevatten. Kijk in de documentatie van de judge die je gebruikt om te zien welke bestanden worden verwacht. Je kan links naar de documentatie voor elke judge [hier](/nl/references/judges) vinden.
 - **Een optionele `workdir`-map**: de inhoud van deze map wordt beschikbaar gesteld tijdens het uitvoeren van de judge en kan bijvoorbeeld databestanden bevatten die nodig zijn tijdens het uitvoeren van de tests.
 - **Een optionele `solution`-map**: bestanden in deze map zullen getoond worden op de oefening-informatiepagina als voorbeeldoplossing. Meerdere voorbeeldoplossingen zijn mogelijk, maar bestanden met een naam beginnend met *solution* zullen vooraan staan.
 

--- a/nl/references/exercise-directory-structure/README.md
+++ b/nl/references/exercise-directory-structure/README.md
@@ -24,7 +24,7 @@ Neem een kijkje in de [voorbeeldoefeningenrepository](https://github.com/dodona-
 Binnenin de `description`-map kan je volgende mappen specifiëren:
 - **Een optionele `media`-map**: deze map bevat statische bestanden zoals afbeeldingen die gebruikt worden in de oefeningbeschrijving.
 - **Een optionele `boilerplate`-map**: deze map bevat de bestanden `boilerplate.en`, `boilerplate.nl`, en/of `boilerplate`. De inhoud van deze bestanden worden automatisch ingeladen in het inzendingstekstveld van de gebruikers. Je kan deze bestanden gebruiken om startcode of structuur te voorzien voor de studenten.
-- **Een `evaluation`-map**: de inhoud van deze map wordt beschikbaar gesteld voor de judge en kan bijvoorbeeld bestanden met de testcode bevatten.
+- **Een `evaluation`-map**: de inhoud van deze map wordt beschikbaar gesteld voor de judge en kan bijvoorbeeld bestanden met de testcode bevatten. Kijk in de documentatie van de judge die u gebruikt om te zien welke bestanden worden verwacht. U vindt links naar de documentatie voor elke judge [hier](/nl/references/judges).
 - **Een optionele `workdir`-map**: de inhoud van deze map wordt beschikbaar gesteld tijdens het uitvoeren van de judge en kan bijvoorbeeld databestanden bevatten die nodig zijn tijdens het uitvoeren van de tests.
 - **Een optionele `solution`-map**: bestanden in deze map zullen getoond worden op de oefening-informatiepagina als voorbeeldoplossing. Meerdere voorbeeldoplossingen zijn mogelijk, maar bestanden met een naam beginnend met *solution* zullen vooraan staan.
 

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -68,9 +68,9 @@ Haskell is een judge die HUnit gebruikt om haskell-oefeningen te testen. \
 **Aan de slag** [Github repo](https://github.com/dodona-edu/judge-haskell), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/haskell) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-## Schema
+## Scheme
 Scheme is een judge die gebruikt kan worden voor oefeningen in de programmeertaal Scheme.\
-**Programmeertalen:** Schema\
+**Programmeertalen:** Scheme\
 **Aan de slag** Neem contact op met de makers voor meer informatie over deze judge.\
 **Gemaakt door:** [Mathijs Saey](mailto:mathijs.saey@vub.be)
 

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -17,8 +17,8 @@ Gevorderde gebruikers kunnen ook hun eigen judge aanmaken, zie [deze gids](/nl/g
 
 Dodona ondersteunt momenteel de volgende judges:
 
-## TESTED
-TESTED is een whitebox judge die voor meerdere programmeertalen gebruikt kan worden.
+## TESTed
+TESTed is een whitebox judge die voor meerdere programmeertalen gebruikt kan worden.
 Het gebruikt een eenvoudig eigen testformaat, dat onafhankelijk is van de programmeertaal.\
 **Programmeertalen:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python\
 **Aan de slag** [Documentatie](/nl/tested#oefeningen-ontwerpen-voor-dodona), [voorbeelden](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -83,14 +83,14 @@ De HTML judge beoordeelt zowel de HTML als de CSS code van een student, op basis
 ## Turtle
 De Turtle judge evalueert de uitvoer van een Python turtle programma. Het berekent de overeenkomst tussen de uitvoer van de leerling en de modeloplossing. \
 **Programmeertalen:** Python (Turtle)**
-**Aan de slag** [Documentatie] (https://github.com/dodona-edu/judge-turtle) \
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-turtle) \
 **Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ## Markdown
 De markdown judge is geen echte judge omdat hij geen code evalueert.
 Het geeft wel de markdown code van een leerling weer en kan handig zijn om de uitvoer handmatig te evalueren in Dodona. \
 **Programmeertalen:** Markdown\
-**Aan de slag** [Documentatie] (https://github.com/dodona-edu/judge-markdown) \
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-markdown) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ## Javascript

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -37,8 +37,8 @@ R is een judge die gebruikt kan worden voor oefeningen in de programmeertaal R.\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-r), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/R) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-## JUnit
-JUnit gebruikt het JUnit4-framework om tests op java-oefeningen uit te voeren.\
+## Java
+Java is judge die het JUnit4-framework gebruikt om tests op java-oefeningen uit te voeren.\
 **Programmeertalen:** Java\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java), [voorbeelden](https://github.com/dodona-edu/judge-java/tree/master/examples) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
@@ -116,8 +116,8 @@ Als u uw eigen C#-oefeningen wilt maken, raden we u aan in plaats daarvan de [TE
 **Aan de slag** [Voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-## Java (Deprecated)
-De Java judge is een JUnit judge voor java8 oefeningen.
+## JUnit (Deprecated)
+De JUnit judge is een JUnit judge voor java8 oefeningen.
 Het is verouderd en mag alleen gebruikt worden voor oude oefeningen.
 Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [JUnit judge](#junit) te gebruiken. \
 **Programmeertalen:** Java \

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -1,0 +1,144 @@
+---
+titel: Judges
+beschrijving: "Overzicht van alle judges beschikbaar op Dodona".
+---
+
+Deze gids is geschreven voor docenten die oefeningen maken voor Dodona.
+
+Voordat je een oefening maakt, moet je beslissen welke `judge` je wilt gebruiken.
+De `judge` is het programma dat de inzendingen van leerlingen beoordeelt.
+Het is vaak geschreven voor één specifieke programmeertaal, of voor een reeks programmeertalen.
+Elke `judge` heeft zijn eigen configuratie-opties, we geven hieronder een link naar de relevante documentatie voor elke `judge`.
+Deze judge specifieke opties moeten worden voorzien in de `evaluation` directory van de [oefening configuratie](/nl/references/exercise-directory-structure).
+
+Gevorderde gebruikers kunnen ook hun eigen judge aanmaken, zie [deze gids](/nl/guides/creating-a-judge).
+
+
+Dodona ondersteunt momenteel de volgende judges:
+* [TESTed](/nl/references/judges#tested)
+* [Python](/nl/references/judges#python)
+* [R](/nl/references/judges#r)
+* [JUnit](/nl/references/judges#junit)
+* [C](/nl/references/judges#c)
+* [SQL](/nl/references/judges#sql)
+* [Prolog](/nl/references/judges#prolog)
+* [Haskell](/nl/references/judges#haskell)
+* [Scheme](/nl/references/judges#scheme)
+* [HTML](/nl/references/judges#html)
+* [Turtle](/nl/references/judges#turtle)
+* [Markdown](/nl/references/judges#markdown)
+* [Java](/nl/references/judges#java)
+* [JavaScript](/nl/references/judges#javascript)
+* [Csharp (Deprecated)](/nl/references/judges#csharp)
+* [Bash (Deprecated)](/nl/references/judges#bash)
+
+### TESTED
+TESTED is een whitebox judge die voor meerdere programmeertalen gebruikt kan worden.
+Het gebruikt een eenvoudig eigen testformaat, dat onafhankelijk is van de programmeertaal.
+**Programmeertalen:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python.
+**Aan de slag** [Documentatie](/nl/references/tested#ontwerp-oefeningen-voor-dodona), [voorbeelden](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
+**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+
+### Python
+Python/Pythia is de eerste judge die is gemaakt voor Dodona.
+Het is een python judge die eenvoudige input/output tests of meer geavanceerde doctests mogelijk maakt.
+**Programmeertalen:** Python.
+**Aan de slag** [Documentatie](/nl/references/python-judge), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/python) \
+**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+
+### R
+R is een judge die gebruikt kan worden voor oefeningen in de programmeertaal R.
+**Programmeertalen:** R
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-r), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/R) \
+**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+
+### JUnit
+JUnit gebruikt het JUnit4-framework om tests op java-oefeningen uit te voeren.
+**Programmeertalen:** Java
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java), [voorbeelden](https://github.com/dodona-edu/judge-java/tree/master/examples) \
+**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+
+### C
+C is een judge die het GTester framework gebruikt om testen uit te voeren op C oefeningen.\
+**Programmeertalen:** C
+**Aan de slag** [Documentatie](https://github.com/mvdcamme/C-Judge), [voorbeelden](https://github.com/mvdcamme/C-Judge/tree/master/example_exercises) \
+**Gemaakt door:** [Maarten Vandercammen](mailto:mvdcamme@vub.ac.be)
+
+### SQL
+De SQL judge ondersteunt zowel query evaluatie (DML) als structurele database opbouw (DDL).**
+**Programmeertalen:** SQL
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-sql), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/sql) \
+**Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+
+### Prolog
+Prolog is een judge die gebruikt kan worden voor oefeningen in de prolog programmeertaal.
+Het ondersteunt PLUnit, QuickCheck en eenvoudige input-outputtests.\
+**Programmeertalen:** Prolog
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-prolog), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
+**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+
+### Haskell
+Haskell is een judge die HUnit gebruikt om haskell-oefeningen te testen. \
+**Programmeertalen:** Haskell
+**Aan de slag** [Github repo](https://github.com/dodona-edu/judge-haskell), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/haskell) \
+**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+
+### Schema
+Scheme is een judge die gebruikt kan worden voor oefeningen in de programmeertaal Scheme.
+**Programmeertalen:** Schema.
+**Neem contact op met de makers voor meer informatie over deze judge.
+**Gemaakt door:** [Mathijs Saey](mailto:mathijs.saey@vub.be)
+
+
+### HTML
+De HTML judge beoordeelt zowel de HTML als de CSS code van een student, op basis van een modeloplossing of een checklist met criteria.
+**Programmeertalen:** HTML, CSS.
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-html), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/html) \
+**Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+
+### Turtle
+De Turtle judge evalueert de uitvoer van een python turtle programma. Het berekent de overeenkomst tussen de uitvoer van de leerling en de modeloplossing. \
+**Programmeertalen:** Python (Turtle)**
+**Aan de slag** [Documentatie] (https://github.com/dodona-edu/judge-turtle) \
+**Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+
+### Markdown
+De markdown judge is geen echte judge omdat hij geen code evalueert.
+Het geeft wel de markdown code van een leerling weer en kan handig zijn om de uitvoer handmatig te evalueren in Dodona. \
+**Programmeertalen:** Markdown.
+**Aan de slag** [Documentatie] (https://github.com/dodona-edu/judge-markdown) \
+**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+
+### Javascript
+Javascript is een judge die gebruikt kan worden voor oefeningen in de javascript programmeertaal.
+Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
+Als je je eigen javascript oefeningen wilt maken, raden we je aan om de [TESTed judge](/nl/references/judges#tested) te gebruiken.
+**Programmeertalen:** Javascript
+**Aan de slag** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
+**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+
+### Bash
+Bash is een judge die gebruikt kan worden voor oefeningen op de bash terminal.
+Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
+Als u uw eigen bash-oefeningen wilt maken, raden we u aan in plaats daarvan de [TESTed judge](/nl/references/judges#tested) te gebruiken.
+**Programmeertalen:** Bash.
+**Aan de slag** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), neem contact op met de makers voor meer informatie over deze judge. \
+**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+
+### Csharp (Afgeschreven)
+De Csharp judge is verouderd en mag alleen gebruikt worden voor oude oefeningen.
+Als u uw eigen C#-oefeningen wilt maken, raden we u aan in plaats daarvan de [TESTed judge](/nl/references/judges#tested) te gebruiken.\
+**Programmeertalen:** C#
+**Aan de slag** [Voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
+**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+
+### Java (Deprecated)
+De Java judge is een JUnit judge voor java8 oefeningen.
+Het is verouderd en mag alleen gebruikt worden voor oude oefeningen.
+Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [JUnit judge](/nl/references/judges#junit) te gebruiken.
+**Programmeertalen:** Java
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java8), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/java) \
+**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+
+Vertaald met www.DeepL.com/Translator (gratis versie)
+

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -7,8 +7,8 @@ description: "Overzicht van alle judges beschikbaar op Dodona"
 
 Deze gids is geschreven voor docenten die oefeningen maken voor Dodona.
 
-Voordat je een oefening maakt, moet je beslissen welke `judge` je wilt gebruiken.
-De `judge` is het programma dat de inzendingen van leerlingen beoordeelt.
+Voordat je een oefening maakt, moet je beslissen welke _judge_ je wilt gebruiken.
+De judge is het programma dat de inzendingen van leerlingen beoordeelt.
 Het is vaak geschreven voor één specifieke programmeertaal, of voor een reeks programmeertalen.
 Elke judge heeft zijn eigen configuratie-opties.
 We geven hieronder een link naar de relevante documentatie voor elke judge.
@@ -23,26 +23,26 @@ TESTed is een whitebox judge die voor meerdere programmeertalen gebruikt kan wor
 Het gebruikt een eenvoudig eigen testformaat, dat onafhankelijk is van de programmeertaal.\
 **Programmeertalen:** Bash, C, C#, Haskell, Java, JavaScript, Kotlin, Python\
 **Aan de slag** [Documentatie](/nl/tested#oefeningen-ontwerpen-voor-dodona), [voorbeelden](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
-**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Python
 Python/Pythia is de eerste judge die is gemaakt voor Dodona.
 Het is een Python judge die eenvoudige input/output tests of meer geavanceerde doctests mogelijk maakt.\
 **Programmeertalen:** Python\
 **Aan de slag** [Documentatie](/nl/references/python-judge), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/python) \
-**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## R
 R is een judge die gebruikt kan worden voor oefeningen in de programmeertaal R.\
 **Programmeertalen:** R\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-r), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/R) \
-**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Java
 Java is judge die het JUnit4-framework gebruikt om tests op Java-oefeningen uit te voeren.\
 **Programmeertalen:** Java\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java), [voorbeelden](https://github.com/dodona-edu/judge-java/tree/master/examples) \
-**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## C
 C is een judge die het GTester-framework gebruikt om testen uit te voeren op C-oefeningen.\
@@ -67,13 +67,13 @@ Prolog is een judge die gebruikt kan worden voor oefeningen in de programmeertaa
 Het ondersteunt PLUnit, QuickCheck en eenvoudige input-outputtests.\
 **Programmeertalen:** Prolog\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-prolog), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
-**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Haskell
 Haskell is een judge die HUnit gebruikt om Haskell-oefeningen te testen. \
 **Programmeertalen:** Haskell\
 **Aan de slag** [Github repo](https://github.com/dodona-edu/judge-haskell), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/haskell) \
-**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## HTML
 De HTML judge beoordeelt zowel de HTML- als de CSS-code van een student, op basis van een modeloplossing of een checklist met criteria.\
@@ -92,7 +92,7 @@ De Markdown-judge is geen echte judge omdat hij geen code evalueert.
 Het geeft wel de markdown code van een leerling weer en kan handig zijn om de uitvoer handmatig te evalueren in Dodona. \
 **Programmeertalen:** Markdown\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-markdown) \
-**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Javascript
 JavaScript is een judge die gebruikt kan worden voor oefeningen in de programmeertaal JavaScript.
@@ -100,7 +100,7 @@ Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
 Als je je eigen JavaScriptoefeningen wilt maken, raden we je aan om de [TESTed-judge](#tested) te gebruiken.\
 **Programmeertalen:** Javascript\
 **Aan de slag** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
-**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Bash
 Bash is een judge die gebruikt kan worden voor oefeningen op de Bash terminal.
@@ -108,14 +108,14 @@ Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
 Als je je eigen Bash-oefeningen wilt maken, raden we aan in plaats daarvan de [TESTed-judge](#tested) te gebruiken.\
 **Programmeertalen:** Bash\
 **Aan de slag** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), neem contact op met de makers voor meer informatie over deze judge. \
-**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Csharp (Deprecated)
 De Csharp-judge is verouderd en mag alleen gebruikt worden voor oude oefeningen.
 Als je je eigen C#-oefeningen wilt maken, raden we aan in plaats daarvan de [TESTed judge](#tested) te gebruiken.\
 **Programmeertalen:** C# \
 **Aan de slag** [Voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
-**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## JUnit (Deprecated)
 De JUnit-judge gebruikt het JUnit-framework  voor oefeningen in de programmeertaal Java 8.
@@ -123,4 +123,4 @@ Het is verouderd en mag alleen gebruikt worden voor oude oefeningen.
 Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [Java-judge](#java) te gebruiken. \
 **Programmeertalen:** Java \
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java8), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/java) \
-**Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -119,7 +119,7 @@ Als u uw eigen C#-oefeningen wilt maken, raden we u aan in plaats daarvan de [TE
 ## JUnit (Deprecated)
 De JUnit judge is een JUnit judge voor java8 oefeningen.
 Het is verouderd en mag alleen gebruikt worden voor oude oefeningen.
-Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [JUnit judge](#junit) te gebruiken. \
+Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [Java judge](#java) te gebruiken. \
 **Programmeertalen:** Java \
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java8), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/java) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -38,7 +38,7 @@ R is een judge die gebruikt kan worden voor oefeningen in de programmeertaal R.\
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ## Java
-Java is judge die het JUnit4-framework gebruikt om tests op java-oefeningen uit te voeren.\
+Java is judge die het JUnit4-framework gebruikt om tests op Java-oefeningen uit te voeren.\
 **Programmeertalen:** Java\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java), [voorbeelden](https://github.com/dodona-edu/judge-java/tree/master/examples) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
@@ -69,7 +69,7 @@ Het ondersteunt PLUnit, QuickCheck en eenvoudige input-outputtests.\
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ## Haskell
-Haskell is een judge die HUnit gebruikt om haskell-oefeningen te testen. \
+Haskell is een judge die HUnit gebruikt om Haskell-oefeningen te testen. \
 **Programmeertalen:** Haskell\
 **Aan de slag** [Github repo](https://github.com/dodona-edu/judge-haskell), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/haskell) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
@@ -94,9 +94,9 @@ Het geeft wel de markdown code van een leerling weer en kan handig zijn om de ui
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ## Javascript
-Javascript is een judge die gebruikt kan worden voor oefeningen in de javascript programmeertaal.
+JavaScript is een judge die gebruikt kan worden voor oefeningen in de JavaScript programmeertaal.
 Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
-Als je je eigen javascript oefeningen wilt maken, raden we je aan om de [TESTed judge](#tested) te gebruiken.\
+Als je je eigen JavaScriptoefeningen wilt maken, raden we je aan om de [TESTed judge](#tested) te gebruiken.\
 **Programmeertalen:** Javascript\
 **Aan de slag** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
@@ -117,7 +117,7 @@ Als u uw eigen C#-oefeningen wilt maken, raden we u aan in plaats daarvan de [TE
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ## JUnit (Deprecated)
-De JUnit judge is een JUnit judge voor java8 oefeningen.
+De JUnit judge is een JUnit judge voor Java 8 oefeningen.
 Het is verouderd en mag alleen gebruikt worden voor oude oefeningen.
 Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [Java judge](#java) te gebruiken. \
 **Programmeertalen:** Java \

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -1,7 +1,9 @@
 ---
-titel: Judges
-beschrijving: "Overzicht van alle judges beschikbaar op Dodona".
+title: Judges
+description: "Overzicht van alle judges beschikbaar op Dodona"
 ---
+
+# Judges
 
 Deze gids is geschreven voor docenten die oefeningen maken voor Dodona.
 
@@ -13,132 +15,111 @@ Deze judge specifieke opties moeten worden voorzien in de `evaluation` directory
 
 Gevorderde gebruikers kunnen ook hun eigen judge aanmaken, zie [deze gids](/nl/guides/creating-a-judge).
 
-
 Dodona ondersteunt momenteel de volgende judges:
-* [TESTed](#tested)
-* [Python](#python)
-* [R](#r)
-* [JUnit](#junit)
-* [C](#c)
-* [SQL](#sql)
-* [Prolog](#prolog)
-* [Haskell](#haskell)
-* [Scheme](#scheme)
-* [HTML](#html)
-* [Turtle](#turtle)
-* [Markdown](#markdown)
-* [JavaScript](#javascript)
-* [Bash](#bash)
-* [Csharp (Deprecated)](#csharp-(deprecated))
-* [Java (Deprecated)](#java-(deprecated)))
 
-### TESTED
+## TESTED
 TESTED is een whitebox judge die voor meerdere programmeertalen gebruikt kan worden.
-Het gebruikt een eenvoudig eigen testformaat, dat onafhankelijk is van de programmeertaal.
-**Programmeertalen:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python.
+Het gebruikt een eenvoudig eigen testformaat, dat onafhankelijk is van de programmeertaal.\
+**Programmeertalen:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python\
 **Aan de slag** [Documentatie](/nl/tested#oefeningen-ontwerpen-voor-dodona), [voorbeelden](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-### Python
+## Python
 Python/Pythia is de eerste judge die is gemaakt voor Dodona.
-Het is een python judge die eenvoudige input/output tests of meer geavanceerde doctests mogelijk maakt.
-**Programmeertalen:** Python.
+Het is een python judge die eenvoudige input/output tests of meer geavanceerde doctests mogelijk maakt.\
+**Programmeertalen:** Python\
 **Aan de slag** [Documentatie](/nl/references/python-judge), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/python) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-### R
-R is een judge die gebruikt kan worden voor oefeningen in de programmeertaal R.
-**Programmeertalen:** R
+## R
+R is een judge die gebruikt kan worden voor oefeningen in de programmeertaal R.\
+**Programmeertalen:** R\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-r), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/R) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-### JUnit
-JUnit gebruikt het JUnit4-framework om tests op java-oefeningen uit te voeren.
-**Programmeertalen:** Java
+## JUnit
+JUnit gebruikt het JUnit4-framework om tests op java-oefeningen uit te voeren.\
+**Programmeertalen:** Java\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java), [voorbeelden](https://github.com/dodona-edu/judge-java/tree/master/examples) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-### C
+## C
 C is een judge die het GTester framework gebruikt om testen uit te voeren op C oefeningen.\
-**Programmeertalen:** C
+**Programmeertalen:** C\
 **Aan de slag** [Documentatie](https://github.com/mvdcamme/C-Judge), [voorbeelden](https://github.com/mvdcamme/C-Judge/tree/master/example_exercises) \
 **Gemaakt door:** [Maarten Vandercammen](mailto:mvdcamme@vub.ac.be)
 
-### SQL
-De SQL judge ondersteunt zowel query evaluatie (DML) als structurele database opbouw (DDL).**
-**Programmeertalen:** SQL
+## SQL
+De SQL judge ondersteunt zowel query evaluatie (DML) als structurele database opbouw (DDL).\
+**Programmeertalen:** SQL\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-sql), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/sql) \
 **Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
-### Prolog
+## Prolog
 Prolog is een judge die gebruikt kan worden voor oefeningen in de prolog programmeertaal.
 Het ondersteunt PLUnit, QuickCheck en eenvoudige input-outputtests.\
-**Programmeertalen:** Prolog
+**Programmeertalen:** Prolog\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-prolog), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-### Haskell
+## Haskell
 Haskell is een judge die HUnit gebruikt om haskell-oefeningen te testen. \
-**Programmeertalen:** Haskell
+**Programmeertalen:** Haskell\
 **Aan de slag** [Github repo](https://github.com/dodona-edu/judge-haskell), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/haskell) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-### Schema
-Scheme is een judge die gebruikt kan worden voor oefeningen in de programmeertaal Scheme.
-**Programmeertalen:** Schema.
-**Neem contact op met de makers voor meer informatie over deze judge.
+## Schema
+Scheme is een judge die gebruikt kan worden voor oefeningen in de programmeertaal Scheme.\
+**Programmeertalen:** Schema\
+**Aan de slag** Neem contact op met de makers voor meer informatie over deze judge.\
 **Gemaakt door:** [Mathijs Saey](mailto:mathijs.saey@vub.be)
 
-
-### HTML
-De HTML judge beoordeelt zowel de HTML als de CSS code van een student, op basis van een modeloplossing of een checklist met criteria.
-**Programmeertalen:** HTML, CSS.
+## HTML
+De HTML judge beoordeelt zowel de HTML als de CSS code van een student, op basis van een modeloplossing of een checklist met criteria.\
+**Programmeertalen:** HTML, CSS\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-html), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/html) \
 **Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
-### Turtle
+## Turtle
 De Turtle judge evalueert de uitvoer van een python turtle programma. Het berekent de overeenkomst tussen de uitvoer van de leerling en de modeloplossing. \
 **Programmeertalen:** Python (Turtle)**
 **Aan de slag** [Documentatie] (https://github.com/dodona-edu/judge-turtle) \
 **Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
-### Markdown
+## Markdown
 De markdown judge is geen echte judge omdat hij geen code evalueert.
 Het geeft wel de markdown code van een leerling weer en kan handig zijn om de uitvoer handmatig te evalueren in Dodona. \
-**Programmeertalen:** Markdown.
+**Programmeertalen:** Markdown\
 **Aan de slag** [Documentatie] (https://github.com/dodona-edu/judge-markdown) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-### Javascript
+## Javascript
 Javascript is een judge die gebruikt kan worden voor oefeningen in de javascript programmeertaal.
 Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
-Als je je eigen javascript oefeningen wilt maken, raden we je aan om de [TESTed judge](#tested) te gebruiken.
-**Programmeertalen:** Javascript
+Als je je eigen javascript oefeningen wilt maken, raden we je aan om de [TESTed judge](#tested) te gebruiken.\
+**Programmeertalen:** Javascript\
 **Aan de slag** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-### Bash
+## Bash
 Bash is een judge die gebruikt kan worden voor oefeningen op de bash terminal.
 Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
-Als u uw eigen bash-oefeningen wilt maken, raden we u aan in plaats daarvan de [TESTed judge](#tested) te gebruiken.
-**Programmeertalen:** Bash.
+Als u uw eigen bash-oefeningen wilt maken, raden we u aan in plaats daarvan de [TESTed judge](#tested) te gebruiken.\
+**Programmeertalen:** Bash.\
 **Aan de slag** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), neem contact op met de makers voor meer informatie over deze judge. \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-### Csharp (Deprecated)
+## Csharp (Deprecated)
 De Csharp judge is verouderd en mag alleen gebruikt worden voor oude oefeningen.
 Als u uw eigen C#-oefeningen wilt maken, raden we u aan in plaats daarvan de [TESTed judge](#tested) te gebruiken.\
-**Programmeertalen:** C#
+**Programmeertalen:** C# \
 **Aan de slag** [Voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-### Java (Deprecated)
+## Java (Deprecated)
 De Java judge is een JUnit judge voor java8 oefeningen.
 Het is verouderd en mag alleen gebruikt worden voor oude oefeningen.
-Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [JUnit judge](#junit) te gebruiken.
-**Programmeertalen:** Java
+Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [JUnit judge](#junit) te gebruiken. \
+**Programmeertalen:** Java \
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java8), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/java) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
-
-Vertaald met www.DeepL.com/Translator (gratis versie)
-

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -26,7 +26,7 @@ Het gebruikt een eenvoudig eigen testformaat, dat onafhankelijk is van de progra
 
 ## Python
 Python/Pythia is de eerste judge die is gemaakt voor Dodona.
-Het is een python judge die eenvoudige input/output tests of meer geavanceerde doctests mogelijk maakt.\
+Het is een Python judge die eenvoudige input/output tests of meer geavanceerde doctests mogelijk maakt.\
 **Programmeertalen:** Python\
 **Aan de slag** [Documentatie](/nl/references/python-judge), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/python) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
@@ -81,7 +81,7 @@ De HTML judge beoordeelt zowel de HTML als de CSS code van een student, op basis
 **Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ## Turtle
-De Turtle judge evalueert de uitvoer van een python turtle programma. Het berekent de overeenkomst tussen de uitvoer van de leerling en de modeloplossing. \
+De Turtle judge evalueert de uitvoer van een Python turtle programma. Het berekent de overeenkomst tussen de uitvoer van de leerling en de modeloplossing. \
 **Programmeertalen:** Python (Turtle)**
 **Aan de slag** [Documentatie] (https://github.com/dodona-edu/judge-turtle) \
 **Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -15,28 +15,28 @@ Gevorderde gebruikers kunnen ook hun eigen judge aanmaken, zie [deze gids](/nl/g
 
 
 Dodona ondersteunt momenteel de volgende judges:
-* [TESTed](/nl/references/judges#tested)
-* [Python](/nl/references/judges#python)
-* [R](/nl/references/judges#r)
-* [JUnit](/nl/references/judges#junit)
-* [C](/nl/references/judges#c)
-* [SQL](/nl/references/judges#sql)
-* [Prolog](/nl/references/judges#prolog)
-* [Haskell](/nl/references/judges#haskell)
-* [Scheme](/nl/references/judges#scheme)
-* [HTML](/nl/references/judges#html)
-* [Turtle](/nl/references/judges#turtle)
-* [Markdown](/nl/references/judges#markdown)
-* [Java](/nl/references/judges#java)
-* [JavaScript](/nl/references/judges#javascript)
-* [Csharp (Deprecated)](/nl/references/judges#csharp)
-* [Bash (Deprecated)](/nl/references/judges#bash)
+* [TESTed](#tested)
+* [Python](#python)
+* [R](#r)
+* [JUnit](#junit)
+* [C](#c)
+* [SQL](#sql)
+* [Prolog](#prolog)
+* [Haskell](#haskell)
+* [Scheme](#scheme)
+* [HTML](#html)
+* [Turtle](#turtle)
+* [Markdown](#markdown)
+* [JavaScript](#javascript)
+* [Bash](#bash)
+* [Csharp (Deprecated)](#csharp-(deprecated))
+* [Java (Deprecated)](#java-(deprecated)))
 
 ### TESTED
 TESTED is een whitebox judge die voor meerdere programmeertalen gebruikt kan worden.
 Het gebruikt een eenvoudig eigen testformaat, dat onafhankelijk is van de programmeertaal.
 **Programmeertalen:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python.
-**Aan de slag** [Documentatie](/nl/references/tested#ontwerp-oefeningen-voor-dodona), [voorbeelden](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
+**Aan de slag** [Documentatie](/nl/tested#oefeningen-ontwerpen-voor-dodona), [voorbeelden](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ### Python
@@ -112,7 +112,7 @@ Het geeft wel de markdown code van een leerling weer en kan handig zijn om de ui
 ### Javascript
 Javascript is een judge die gebruikt kan worden voor oefeningen in de javascript programmeertaal.
 Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
-Als je je eigen javascript oefeningen wilt maken, raden we je aan om de [TESTed judge](/nl/references/judges#tested) te gebruiken.
+Als je je eigen javascript oefeningen wilt maken, raden we je aan om de [TESTed judge](#tested) te gebruiken.
 **Programmeertalen:** Javascript
 **Aan de slag** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
@@ -120,14 +120,14 @@ Als je je eigen javascript oefeningen wilt maken, raden we je aan om de [TESTed 
 ### Bash
 Bash is een judge die gebruikt kan worden voor oefeningen op de bash terminal.
 Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
-Als u uw eigen bash-oefeningen wilt maken, raden we u aan in plaats daarvan de [TESTed judge](/nl/references/judges#tested) te gebruiken.
+Als u uw eigen bash-oefeningen wilt maken, raden we u aan in plaats daarvan de [TESTed judge](#tested) te gebruiken.
 **Programmeertalen:** Bash.
 **Aan de slag** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), neem contact op met de makers voor meer informatie over deze judge. \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
-### Csharp (Afgeschreven)
+### Csharp (Deprecated)
 De Csharp judge is verouderd en mag alleen gebruikt worden voor oude oefeningen.
-Als u uw eigen C#-oefeningen wilt maken, raden we u aan in plaats daarvan de [TESTed judge](/nl/references/judges#tested) te gebruiken.\
+Als u uw eigen C#-oefeningen wilt maken, raden we u aan in plaats daarvan de [TESTed judge](#tested) te gebruiken.\
 **Programmeertalen:** C#
 **Aan de slag** [Voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
@@ -135,7 +135,7 @@ Als u uw eigen C#-oefeningen wilt maken, raden we u aan in plaats daarvan de [TE
 ### Java (Deprecated)
 De Java judge is een JUnit judge voor java8 oefeningen.
 Het is verouderd en mag alleen gebruikt worden voor oude oefeningen.
-Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [JUnit judge](/nl/references/judges#junit) te gebruiken.
+Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [JUnit judge](#junit) te gebruiken.
 **Programmeertalen:** Java
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java8), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/java) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -55,6 +55,12 @@ De SQL judge ondersteunt zowel query evaluatie (DML) als structurele database op
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-sql), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/sql) \
 **Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
+## Scheme
+Scheme is een judge die de `R5RS` variant van de scheme programmeertaal ondersteunt. Het gebruikt een aangepast testframework [dunit](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/collects/dunit) om de tests te definiëren.\
+**Programmeertalen:** Scheme \
+**Aan de slag** [Documentatie](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge), [voorbeelden](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/example-exercises) \
+**Gemaakt door:** [Mathijs Saey](mailto:scpi@dinf.vub.ac.be)
+
 ## Prolog
 Prolog is een judge die gebruikt kan worden voor oefeningen in de prolog programmeertaal.
 Het ondersteunt PLUnit, QuickCheck en eenvoudige input-outputtests.\
@@ -67,12 +73,6 @@ Haskell is een judge die HUnit gebruikt om haskell-oefeningen te testen. \
 **Programmeertalen:** Haskell\
 **Aan de slag** [Github repo](https://github.com/dodona-edu/judge-haskell), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/haskell) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
-
-## Scheme
-Scheme is een judge die gebruikt kan worden voor oefeningen in de programmeertaal Scheme.\
-**Programmeertalen:** Scheme\
-**Aan de slag** Neem contact op met de makers voor meer informatie over deze judge.\
-**Gemaakt door:** [Mathijs Saey](mailto:mathijs.saey@vub.be)
 
 ## HTML
 De HTML judge beoordeelt zowel de HTML als de CSS code van een student, op basis van een modeloplossing of een checklist met criteria.\

--- a/nl/references/judges/README.md
+++ b/nl/references/judges/README.md
@@ -10,8 +10,9 @@ Deze gids is geschreven voor docenten die oefeningen maken voor Dodona.
 Voordat je een oefening maakt, moet je beslissen welke `judge` je wilt gebruiken.
 De `judge` is het programma dat de inzendingen van leerlingen beoordeelt.
 Het is vaak geschreven voor één specifieke programmeertaal, of voor een reeks programmeertalen.
-Elke `judge` heeft zijn eigen configuratie-opties, we geven hieronder een link naar de relevante documentatie voor elke `judge`.
-Deze judge specifieke opties moeten worden voorzien in de `evaluation` directory van de [oefening configuratie](/nl/references/exercise-directory-structure).
+Elke judge heeft zijn eigen configuratie-opties.
+We geven hieronder een link naar de relevante documentatie voor elke judge.
+Deze judge specifieke opties moeten worden voorzien in de map `evaluation` van de [oefening-specifieke configuratie](/nl/references/exercise-directory-structure).
 
 Gevorderde gebruikers kunnen ook hun eigen judge aanmaken, zie [deze gids](/nl/guides/creating-a-judge).
 
@@ -20,7 +21,7 @@ Dodona ondersteunt momenteel de volgende judges:
 ## TESTed
 TESTed is een whitebox judge die voor meerdere programmeertalen gebruikt kan worden.
 Het gebruikt een eenvoudig eigen testformaat, dat onafhankelijk is van de programmeertaal.\
-**Programmeertalen:** Bash, C, C#, Haskell, Java, Javascript, Kotlin, Python\
+**Programmeertalen:** Bash, C, C#, Haskell, Java, JavaScript, Kotlin, Python\
 **Aan de slag** [Documentatie](/nl/tested#oefeningen-ontwerpen-voor-dodona), [voorbeelden](https://github.com/dodona-edu/universal-judge/tree/master/exercise) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
@@ -44,7 +45,7 @@ Java is judge die het JUnit4-framework gebruikt om tests op Java-oefeningen uit 
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ## C
-C is een judge die het GTester framework gebruikt om testen uit te voeren op C oefeningen.\
+C is een judge die het GTester-framework gebruikt om testen uit te voeren op C-oefeningen.\
 **Programmeertalen:** C\
 **Aan de slag** [Documentatie](https://github.com/mvdcamme/C-Judge), [voorbeelden](https://github.com/mvdcamme/C-Judge/tree/master/example_exercises) \
 **Gemaakt door:** [Maarten Vandercammen](mailto:mvdcamme@vub.ac.be)
@@ -56,13 +57,13 @@ De SQL judge ondersteunt zowel query evaluatie (DML) als structurele database op
 **Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ## Scheme
-Scheme is een judge die de `R5RS` variant van de scheme programmeertaal ondersteunt. Het gebruikt een aangepast testframework [dunit](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/collects/dunit) om de tests te definiëren.\
+Scheme is een judge die de `R5RS`-variant van de programmeertaal Scheme ondersteunt. Het gebruikt een aangepast testframework [dunit](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/collects/dunit) om de tests te definiëren.\
 **Programmeertalen:** Scheme \
 **Aan de slag** [Documentatie](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge), [voorbeelden](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/example-exercises) \
 **Gemaakt door:** [Mathijs Saey](mailto:scpi@dinf.vub.ac.be)
 
 ## Prolog
-Prolog is een judge die gebruikt kan worden voor oefeningen in de prolog programmeertaal.
+Prolog is een judge die gebruikt kan worden voor oefeningen in de programmeertaal Prolog.
 Het ondersteunt PLUnit, QuickCheck en eenvoudige input-outputtests.\
 **Programmeertalen:** Prolog\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-prolog), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
@@ -75,51 +76,51 @@ Haskell is een judge die HUnit gebruikt om Haskell-oefeningen te testen. \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ## HTML
-De HTML judge beoordeelt zowel de HTML als de CSS code van een student, op basis van een modeloplossing of een checklist met criteria.\
+De HTML judge beoordeelt zowel de HTML- als de CSS-code van een student, op basis van een modeloplossing of een checklist met criteria.\
 **Programmeertalen:** HTML, CSS\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-html), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/html) \
 **Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ## Turtle
-De Turtle judge evalueert de uitvoer van een Python turtle programma. Het berekent de overeenkomst tussen de uitvoer van de leerling en de modeloplossing. \
+De Turtle-judge evalueert de uitvoer van een Python Turtle programma. Het berekent de overeenkomst tussen de uitvoer van de leerling en de modeloplossing. \
 **Programmeertalen:** Python (Turtle)**
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-turtle) \
 **Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
 ## Markdown
-De markdown judge is geen echte judge omdat hij geen code evalueert.
+De Markdown-judge is geen echte judge omdat hij geen code evalueert.
 Het geeft wel de markdown code van een leerling weer en kan handig zijn om de uitvoer handmatig te evalueren in Dodona. \
 **Programmeertalen:** Markdown\
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-markdown) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ## Javascript
-JavaScript is een judge die gebruikt kan worden voor oefeningen in de JavaScript programmeertaal.
+JavaScript is een judge die gebruikt kan worden voor oefeningen in de programmeertaal JavaScript.
 Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
-Als je je eigen JavaScriptoefeningen wilt maken, raden we je aan om de [TESTed judge](#tested) te gebruiken.\
+Als je je eigen JavaScriptoefeningen wilt maken, raden we je aan om de [TESTed-judge](#tested) te gebruiken.\
 **Programmeertalen:** Javascript\
 **Aan de slag** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ## Bash
-Bash is een judge die gebruikt kan worden voor oefeningen op de bash terminal.
+Bash is een judge die gebruikt kan worden voor oefeningen op de Bash terminal.
 Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
-Als u uw eigen bash-oefeningen wilt maken, raden we u aan in plaats daarvan de [TESTed judge](#tested) te gebruiken.\
-**Programmeertalen:** Bash.\
+Als je je eigen Bash-oefeningen wilt maken, raden we aan in plaats daarvan de [TESTed-judge](#tested) te gebruiken.\
+**Programmeertalen:** Bash\
 **Aan de slag** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), neem contact op met de makers voor meer informatie over deze judge. \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ## Csharp (Deprecated)
-De Csharp judge is verouderd en mag alleen gebruikt worden voor oude oefeningen.
-Als u uw eigen C#-oefeningen wilt maken, raden we u aan in plaats daarvan de [TESTed judge](#tested) te gebruiken.\
+De Csharp-judge is verouderd en mag alleen gebruikt worden voor oude oefeningen.
+Als je je eigen C#-oefeningen wilt maken, raden we aan in plaats daarvan de [TESTed judge](#tested) te gebruiken.\
 **Programmeertalen:** C# \
 **Aan de slag** [Voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)
 
 ## JUnit (Deprecated)
-De JUnit judge is een JUnit judge voor Java 8 oefeningen.
+De JUnit-judge gebruikt het JUnit-framework  voor oefeningen in de programmeertaal Java 8.
 Het is verouderd en mag alleen gebruikt worden voor oude oefeningen.
-Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [Java judge](#java) te gebruiken. \
+Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [Java-judge](#java) te gebruiken. \
 **Programmeertalen:** Java \
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java8), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/java) \
 **Gemaakt door:** [Team dodona](mailto:dodona@ugent.be)


### PR DESCRIPTION
This pull requests adds an overview page with all judges currently supported by Dodona.
I tried to already add some links to it from other pages that should logically reference this one.

I made an opinionated ordering based on a how much each judge is used, combined with how much we want to promote further use.

I am not that familiar with most judges, so please double check my description for the judges you are familiar with.

The Dutch version is a proofread translation by DeepL.