### PR TITLE
[TESTed] DSL + runs update

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -250,6 +250,7 @@ function getTESTedSidebar(lang, groupTitle, FirstItem) {
         // These URLs should be stable, since they are published.
         ['', FirstItem],
         'exercise-config/',
+        'dsl/',
         'json/',
         'types/',
         'new-programming-language/',

--- a/en/tested/README.md
+++ b/en/tested/README.md
@@ -44,7 +44,8 @@ If you want to use TESTed outside of Dodona, we recommend following [this tutori
 A number of technical specifications are also available:
 
 - [Configuration options](/en/tested/exercise-config)
-- [Advanced (JSON) test suite format](/en/tested/json) (not recommended for general use)
+- [Reference for DSL test suites](/en/tested/dsl) (recommended)
+- [Reference for advanced test suites](/en/tested/json) (not recommended for general use)
 - [Data types for programming languages](/en/tested/types)
 
 Useful guides if you want to work on TESTed itself:
@@ -179,7 +180,7 @@ Create a new file `config.json` in the `echo` directory, with the following cont
     }
   },
   "evaluation": {
-    "plan_name": "tests.yaml"
+    "test_suite": "tests.yaml"
   },
   "programming_language": "python",
   "access": "private"

--- a/en/tested/README.md
+++ b/en/tested/README.md
@@ -44,7 +44,7 @@ If you want to use TESTed outside of Dodona, we recommend following [this tutori
 A number of technical specifications are also available:
 
 - [Configuration options](/en/tested/exercise-config)
-- [Test suite format](/en/tested/json)
+- [Advanced (JSON) test suite format](/en/tested/json) (not recommended for general use)
 - [Data types for programming languages](/en/tested/types)
 
 Useful guides if you want to work on TESTed itself:
@@ -179,7 +179,7 @@ Create a new file `config.json` in the `echo` directory, with the following cont
     }
   },
   "evaluation": {
-    "plan_name": "tests.json"
+    "plan_name": "tests.yaml"
   },
   "programming_language": "python",
   "access": "private"
@@ -189,7 +189,7 @@ Create a new file `config.json` in the `echo` directory, with the following cont
 This configuration file specifies, in order:
 
 1. An exercise name in Dutch and in English.
-2. The path name of the test suite (`tests.json`) relative to the `echo/evaluation` directory.
+2. The path name of the test suite (`tests.yaml`) relative to the `echo/evaluation` directory.
 3. Python as the default programming language.
    While TESTed supports multiple programming languages, 
    Dodona currently supports only a single programming language per exercise.
@@ -239,53 +239,20 @@ A test suite contains all test cases that will be executed on the submission to 
 
 For brevity, we will only include a single test case in our test suite.
 But a real test suite would contain many more test cases.
-Create a new file `evaluation/tests.json`:
+Create a new file `evaluation/tests.yaml`:
 
-
-```json
-{
- "tabs": [
-  {
-   "name": "Echo",
-   "runs": [
-    {
-     "contexts": [
-      {
-       "testcases": [
-        {
-         "input": {
-          "type": "function",
-          "name": "echo",
-          "arguments": [
-           {
-            "type": "text",
-            "data": "input-1"
-           }
-          ]
-         },
-         "output": {
-          "stdout": {
-           "type": "text",
-           "data": "input-1"
-          }
-         }
-        }
-       ]
-      }
-     ]
-    }
-   ]
-  }
- ]
-}
+```yaml
+- tab: "Echo"
+  testcases:
+     - expression: "echo('input-1')"
+       stdout: "input-1"
 ```
 
 This test suite specifies that:
 
 1. All feedback is included in a single tab called _Echo_.
 2. The tab contains feedback on a single test case.
-3. The test case calls the function `echo` with a string argument `input-1`.
-   Conceptually, this is equivalent to calling `write("input-1")` in Python.
+3. The test case calls the function `echo` with a string argument `"input-1"`.
 4. The expected behavior of the test case is that the text `input-1` is generated on stdout.
 
 
@@ -295,7 +262,7 @@ The file structure now looks like this:
 ├── echo/
 |   ├── config.json
 |   ├── evaluation/
-|   |   └── tests.json
+|   |   └── tests.yaml
 |   ├── description/
 |   |   └── description.en.md
 ```

--- a/en/tested/dsl/README.md
+++ b/en/tested/dsl/README.md
@@ -1,0 +1,384 @@
+---
+title: Reference for DSL test suites
+description: "Easily create test suites for TESTed"
+sidebarDepth: 2
+---
+
+# DSL test suite reference
+
+In TESTed, a test suite specifies which test cases are executed against a submission.
+TESTed differs from other test frameworks in that its test suites are independent of any programming language.
+As a result, a single test suite is sufficient to check submissions for the same exercise in different programming languages.
+
+While TESTed has an [advanced format](/en/tested/json) for the test suites, we have also developed a small _domain-specific language_ (DSL), to make creating common exercises much easier.
+This document is the reference for the DSL test suite format, and contains all options and possibilities.
+
+[//]: # (We also have a set of tutorials, for creating certain types of exercises.)
+
+DSL test suites are written in [YAML](https://en.wikipedia.org/wiki/YAML).
+A JSON Schema of the format is available in the TESTed repository, which can enable checks and autocompletion in your editor.
+
+## Structure
+
+The structure of a DSL test suites follows the general Dodona structure, and consists of three levels:
+
+1. [Tabs](#tabs)
+2. [Contexts](#contexts)
+3. [Test cases](#test-cases)
+
+Below we describe objects of each level.
+Mandatory attributes are indicated with a star (*).
+At the [end of this document](#full-example), there is a full example of a test suite.
+
+### Root of the test suite
+
+The test suite starts with either a root object, or a list of [tabs](#tabs).
+The root object contains three attributes:
+
+- `tabs`*: a list of [tab](#tabs) objects
+- `namespace`: the "namespace" for the code of the submission, such as the class name in Java.
+- `config`: the global [configuration options](#configuration-options)
+
+### Tabs
+
+A tab object maps onto a tab in the output on Dodona.
+It has four possible attributes:
+
+- `tab`*: the name of the tab to be displayed in Dodona
+- `contexts`*: a list of [contexts](#contexts) (if this is given, you cannot use the attribute `testcases`)
+- `testcases`*: a list of [test cases](#test-cases) (if this is given, you cannot use the attribute `contexts`)
+- `config`: the [configuration options](#configuration-options) for this tab and all children
+
+In a lot of exercises, you have precisely one testcase per context.
+This is exactly what you can do using the `testcases` attribute: behind the scenes, each testcase will be placed in its own context.
+
+:::tip Hint
+While there are four possible attributes, each tab object can only have three,
+since `contexts` and `testcases` are mutually exclusive.
+:::
+
+### Contexts
+
+A context is a group of test cases that depend on each other.
+The context object has three attributes:
+
+- `testcases`*: a list of [test cases](#test-cases)
+- `config`: the [configuration options](#configuration-options) for this context and all children
+- `context`: an optional description of the context
+- `files`: optional list of [files](#files)
+
+In most cases, it is fine to leave the description empty.
+
+Each context must have at least one test case.
+Since each context is executed separately, the following two constraints apply:
+
+- Only the first test case may have a "main call", i.e. command line arguments or stdin.
+- Only the last test case may have a test for the program's exit code.
+
+Do note that the first and last test case may be the same one:
+if you only have one test case, it may be a main call and have a check for the exit code.
+
+### Test cases
+
+Test cases are the building blocks of a test suite, and contain some input and the expected outputs (the _tests_).
+Within each context, the following constraints apply to test cases:
+
+- Only the first test case may have a "main call", i.e. command line arguments or stdin.
+- Only the last test case may have a test for the program's exit code.
+
+Do note that the first and last test case may be the same one:
+if you only have one test case, it may be a main call and have a check for the exit code.
+
+A test case can have the following attributes:
+
+- `config`: the [configuration options](#configuration-options) for this test case and all children
+- `files`: optional list of [files](#files)
+
+Additionally, a test case can have all attributes described below, but do note:
+
+- A test case can only have one "input", meaning the `arguments`/`stdin`, `expression` and `statement` attributes are mutually exclusive.
+- The attributes `return` and `return_raw` are mutually exclusive, as an expression can only have one result.
+- The attributes `return`/`return_raw` require either the attribute `expression` or `statement`.
+
+#### `stdin`
+
+The data to provide to the [standard input](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin)).
+
+If this attribute is used, you cannot specify `expression` or `statement` as input, nor can you use `return` or `return_raw` as tests.
+
+#### `arguments`
+
+A list of strings to pass to the program as the [command line arguments](https://en.wikipedia.org/wiki/Command-line_interface#Arguments).
+
+If this attribute is used, you cannot specify `expression` or `statement` as input, nor can you use `return` or `return_raw` as tests.
+
+#### `main_call`
+
+An optional attribute you can set to `true` if you want a main call without stdin and without arguments.
+
+If this attribute is used, you cannot specify `expression` or `statement` as input, nor can you use `return` or `return_raw` as tests.
+
+#### `expression` / `statement`
+
+Contains the expression to evaluate or statement to execute during this test case.
+These attributes are synonyms.
+
+Expressions and statements use the Python syntax, with some restrictions, which are detailed [here](#expressions-and-statements).
+
+#### `stdout` / `stderr`
+
+Specifies the expected output on [standard output](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)) and [standard error](https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr)) respectively.
+
+The attribute is either a string (in which case the string is the expected value), or an object for more advanced cases.
+The object has the following attributes:
+
+- `data`: the expected data, same as using a string
+- `config`: the [configuration options](#test-options)
+
+#### `exception`
+
+Specifies the expected message of an expected exception.
+Note that TESTed currently does not allow checking the exception type or class.
+For example, you cannot check that an assertion error or exception happened.
+
+#### `return` / `return_raw`
+
+Specifies the expected return value.
+In most cases, you can use `return`, in which case the expected return value is encoded into a YAML value (string, number, boolean, etc.).
+However, sometimes you need more advanced representations, in which case `return_raw` allows you to use the same Python syntax as for the [expressions and statements](#expressions-and-statements), with the restriction that you can only use values.
+For example, a return value cannot be a function call.
+
+As mentioned before, these attributes are only allowed if you also specified a `expression`/`statement` as input for the test case.
+You can also not have both `return` and `return_raw` at the same time.
+
+#### `exit_code`
+
+Specifies the expected exit code of the program.
+
+Note that only the last test case of a context can have this attribute, although the last test case can also be the first test case if needed.
+
+### Files
+
+Some parameters or other strings are a name of a file.
+If you want that parameter to link to the actual file, it needs to be added to the list of files.
+Each object in this list has two attributes:
+
+- `name`: the name of the file as it appears in the input
+- `url`: the location where the link should point to, relative to the exercise folder
+
+## Configuration options
+
+The configuration object can be specified on any level and applies to all levels below it.
+For example, specifying the config on the tab level means it will apply to all contexts and, in turn, all test cases within that tab.
+
+The configuration option has two attributes:
+
+- `stdout`: the [configuration options](#test-options) for standard output
+- `stderr`: the [configuration options](#test-options) for standard error
+- `return`: the [configuration options](#test-options) for the expected return value
+
+### Test options
+
+This object contains a set of configuration options that influence how the test results are checked by TESTed.
+The following options are available:
+
+- `applyRounding`: apply rounding when comparing values as float point numbers
+- `roundTo`: the number of decimals to round to, if `applyRouding` is true
+- `caseInsensitive`: ignore the case of text when comparing strings
+- `ignoreWhitespace`: ignore leading and trailing whitespace
+- `tryFloatingPoint`: try comparing text as floating point numbers
+
+## Expressions and statements
+
+In the test suite, expressions and statements are written as YAML strings, using the Python syntax.
+For example, a function call with one argument `"hello"`:
+
+```yaml
+expression: "a_function_name('hello')"
+```
+
+Since the Python syntax does not have a separate syntax for all features supported by TESTed, there are some conventions:
+
+- Function calls whose name begins with a capital are considered constructors, e.g. `Constructor(56)`.
+- Identifiers that are in all caps are considered global constants, e.g. `VERY_LONG_NAME`.
+- Casts are done using the normal Python way. For example, to cast a number to `int64`: `int64(56)`.
+
+Additionally, most of the syntax is not supported, since TESTed only has support for limited expressions and statements.
+The following is supported:
+
+- Simple values, such as `5`, `-9.3` or `"Hello world"`.
+- Complex values, such as `[5, 6, 7]`, `{5, "Hello"}` or `{"key": "value"}`.
+- Function calls, including named arguments `the_function(5, named=6)`. Do note that named arguments are converted to positional arguments in programming languages that do not support named arguments.
+- Constructors (using our convention).
+- Assignments, such as `some_variabel = 5`.
+- Referencing variables, such as `the_function(some_variable)`.
+
+Notably, absent are any type of function or class definitions and all operators.
+
+## YAML cheat sheet
+
+This section contains a very brief overview of the YAML features used in the DSL.
+
+### Objects
+
+Objects in YAML are key-value pairs, where the key (the attribute) and value are separated by a colon:
+
+```yaml
+key: value
+```
+
+Nested objects are created using indentation:
+
+```yaml
+root:
+  child0:
+    subchild0: "leaf"
+    subchild1: "leaf"
+  child1:
+    subchild0: "leaf"
+```
+
+### Lists
+
+Lists in YAML can be written either on one line (using the JSON syntax) or with one value per line.
+For example, a list on one line
+
+```yaml
+["Item 0", "Item 1", "Item 2", "Item 3"]
+```
+
+When using one value per line, each value must be prefixed with a dash (-) and space:
+
+```yaml
+- "Item 0"
+- "Item 1"
+- "Item 2"
+- "Item 3"
+```
+
+You can also combine lists and objects:
+
+```yaml
+list:
+- name: "Item 0"
+  items: 5
+- name: "Item 1"
+- name: "Item 2"
+  items: 3
+- name: "Item 3"
+```
+
+### Strings
+
+Ordinary strings in YAML are written using double quotes:
+
+```yaml
+description: "Hello"
+```
+
+However, doing multi-line strings is rather ugly:
+
+```yaml
+description: "Hello\nWorld"
+```
+
+YAML supports special syntax for multi-line strings.
+Writing the same string as the last example, we get:
+
+```yaml
+description: |
+  Hello
+  World
+```
+
+The reverse is also possible, which are called "folded strings".
+With this syntax, YAML will remove newlines:
+
+```yaml
+description: >
+  Hello
+  World
+```
+
+This is equivalent to writing:
+
+```yaml
+description: "Hello World"
+```
+
+## Full example
+
+```yaml
+# A tab on Dodona.
+- tab: "Name of the tab"
+  contexts:
+    # The files used in this context.
+    - files:
+        - name: "file.txt"
+          url: "media/workdir/file.txt"
+      testcases:
+        # An assignment of the variable data.
+        - statement: 'data = ["list\nline", "file.txt"]'
+          # Function call that uses the variable.
+        - statement: 'function(data, 0.5)'
+          # Expected return value of the function.
+          return: [ 0, 0 ]
+    - testcases:
+        # A function call where the value is cast to "uint8".
+        - statement: 'echo(uint8(5))'
+          # The expected return value is also cast to "uint8".
+          return_raw: "uint8(5)"
+
+# A second tab in the same test suite.
+- tab: "Exception"
+  contexts:
+    - testcases:
+        # Another function call.
+        - statement: 'function_error()'
+          # The expected text on stdout.
+          stdout: "Invalid"
+          # The expected text on stderr.
+          stderr: "Error"
+          # We expect an error or exception with the message "Unknown".
+          exception: "Unknown"
+
+# A third tab.
+- tab: "Arguments"
+  testcases:
+    # This program gets input via stdin.
+    - stdin: "Alice"
+      # There are also command line arguments.
+      arguments: [ "stdin" ]
+      # The expected text on stdout.
+      stdout: "Hello Alice"
+
+# A fourth tab.
+- tab: "Config"
+  # We configure everything on the tab level.
+  config:
+    stdout:
+      # First try to compare text on stdout as float.
+      tryFloatingPoint: true
+      # When comparing floats, round to 2 decimals.
+      applyRounding: true
+      roundTo: 2
+    # On stderr we ignore white space and make it case insensitive.
+    stderr:
+      ignoreWhitespace: true
+      caseInsensitive: true
+  contexts:
+    - config:
+        stdout:
+          # We override the tab configuration for this context.
+          roundTo: 0
+      testcases:
+        - statement: 'diff(5, 2)'
+          stdout: "2"
+        - statement: 'diff(5, 2)'
+          stdout:
+            data: "2.5"
+            # We override the context configuration in this test.
+            config:
+              roundTo: 4
+
+```

--- a/en/tested/exercise-config/README.md
+++ b/en/tested/exercise-config/README.md
@@ -10,18 +10,17 @@ some specific options for TESTed can be used as well.
 
 ## Test suite
 
-The default location of a test suite for TESTed is a JSON file `plan.json` in the `evaluation` directory of the exercise.
-The optional `testplan` attribute in the `evaluation` block takes an alternative location as a path name relative to the `evaluation` directory.
+The `test_suite` attribute in the `evaluation` block takes the location of the test suite as a path name relative to the `evaluation` directory.
 
 ```json
 {
   "evaluation": {
-    "testplan": "plan.json"
+    "test_suite": "plan.yaml"
   }
 }
 ```
 
-See [_Test suite format_](/en/tested/json) for a detailed description of the test suite format for TESTed.
+See the reference documentation for the [DSL test suites](/en/tested/dsl) and the [advanced test suites](/en/tested/json) for a detailed description of the test suite formats.
 
 ## General options
 
@@ -273,7 +272,7 @@ Here's an example of a complete configuration file (`config.json`) for a Dodona 
   },
   "evaluation": {
     "handler": "TESTed",
-    "plan_name": "plan.json",
+    "test_suite": "suite.yaml",
     "options": {
       "mode": "batch",
       "allow_fallback": true,

--- a/en/tested/json/README.md
+++ b/en/tested/json/README.md
@@ -1,14 +1,14 @@
 ---
-title: Advanced test suite reference
-description: "Create test suites for TESTed"
+title: Reference for advanced test suites
+description: "Create advanced test suites for TESTed"
 sidebarDepth: 2
 ---
 
 # Advanced test suite reference
 
-:::tip Advanced test suites vs. DSL test suites
+:::warning Advanced test suites vs. DSL test suites
 This is the reference guide for advanced test suites, written in JSON.
-In most cases, you should prefer using the DSL test suites (written in YAML).
+In most cases, you should prefer using the [DSL test suites](/en/tested/dsl) (written in YAML).
 
 This format is mostly useful if:
 - You generate the test suite programmatically. In this case, JSON might be easier than YAML to write.
@@ -20,7 +20,7 @@ TESTed differs from other test frameworks in that its test suites are independen
 As a result,
 a single test suite is sufficient to check submissions for the same exercise in different programming languages.
 
-[This Python module](https://github.com/dodona-edu/universal-judge/blob/master/tested/testplan.py) formally specifies the TESTed test suite format.
+[This Python module](https://github.com/dodona-edu/universal-judge/blob/master/tested/testsuite.py) formally specifies the TESTed test suite format.
 The module can also generate a JSON Schema to make the validation of test suites easier.
 The [source code repository](https://github.com/dodona-edu/universal-judge/tree/master/exercise) for TESTed contains a number of examples of test suites.
 

--- a/en/tested/json/README.md
+++ b/en/tested/json/README.md
@@ -520,31 +520,34 @@ To support custom datatypes, you must use a `SpecificEvaluator`.
 
 ## Evaluators
 
-There are three ways of checking results in TESTed:
+There are two ways of checking test results in TESTed.
+Both involve implementing or using a "check function",
+which is the code that receives the results from the submission and must decide if it is correct or not.
 
-1. *Built-in checks*
-   These are programming-language-independent, and are the preferred way to use TESTed.
-2. *Programmed checks*
-   In this case, you, as the exercise author, provide an implementation of a function which will be called by TESTed
-   when checking the results.
-   You only have to implement this function once in one programming language.
-   TESTed takes care of translating the results between multiple programming languages.
-   This means these types of checks are still programming-language-independent.
-   A good example is checking non-deterministic behavior, such as randomness or dynamic results, e.g. when results are
-   dependent on the current date.
-3. *Language-specific checks*
-   Here, you need to provide the implementation of a function for each programming language the exercise needs to
-   support.
-   The downside is that the test suite is no longer programming-language-independent.
-   For example, if a new language is added to TESTed, your test suite will need updating.
-   However, this does allow you to test programming-language-specific aspects, such as custom datatypes.
+There are two ways to achieve this:
 
-Internally, these checks are implemented using evaluators.
-The *built-in checks* are implemented using "generic evaluators", which are the default for all output channels.
-This means you often don't need to specify them.
+1. The programming-language-independent way.
+   Here you only need one check function, regardless of the number of programming languages your exercise supports.
+   Internally, the test results will be serialized and deserialized by TESTed before calling the check function.
+   Some functions are built-in to TESTed and are ready to use.
+   These mainly cover basic tests, such as stdout, stderr, return values, etc.
+   In other cases, such as testing with randomness, you will need to implement the check function yourselves
+   (but only once, in a programming language of your choice).
+2. Using language-specific checks.
+   Here, you need to provide a check function in each programming language you want your exercise to support.
+   Since these are executed together with the submission,
+   they are not limited by the serialization process.
+   This means you can test programming-language-specific aspects, such as custom datatypes,
+   but you will need to provide a check function for every programming language.
 
-*Programmed checks* are achieved using the [`SpecificEvaluator`](#specificevaluator).
-*Language-specific checks* are implemented using the [`ProgrammedEvaluator`](#programmedevaluator).
+For the programming-language-independent way,
+you can either use one of the built-in check functions or provide your own.
+
+In a test suite, this translates to three kinds of evaluators:
+
+1. "Generic evaluators" for the built-in check functions.
+2. [`SpecificEvaluator`](#specificevaluator) for a custom check function using the programming-language-independent way.
+3. [`ProgrammedEvaluator`](#programmedevaluator) for custom check functions that are programming language specific.
 
 Each evaluator has an attribute `.type` with the internal type of the evaluator.
 Generic evaluators also have an attribute `.name` with the internal name of the evaluator.

--- a/en/tested/json/README.md
+++ b/en/tested/json/README.md
@@ -19,15 +19,19 @@ The [source code repository](https://github.com/dodona-edu/universal-judge/tree/
 The first section of this reference describes the structure of the test suite.
 A dot notation is used to indicate where the attribute is located in the hierarchical structure.
 A star (`*`) is used to indicate a list of objects.
-For example, `plan.tabs.*.runs.*.run` can roughly be converted to json like this:
+For example, `.tabs.*.contexts.*.testcases.*.description` can roughly be converted to json like this:
 
 ```json5
-{                   // `plan`
- tabs: [            // `plan.tabs`
-  {                 // `plan.tabs.*`
-   runs: [          // `plan.tabs.*.runs`
-    {               // `plan.tabs.*.runs.*` 
-     run: "example" // `plan.tabs.*.runs.*.run`
+{                         // <root>
+ tabs: [                  // .tabs
+  {                       // .tabs.*
+   contexts: [            // .tabs.*.contexts
+    {                     // .tabs.*.contexts.*` 
+     testcases: [         // .tabs.*.contexts.*.testcases
+       {                  // .tabs.*.contexts.*.testcases.*
+         description: "1" // .tabs.*.contexts.*.testcases.*.description
+       }
+     ]
     }
    ]
   }
@@ -37,9 +41,9 @@ For example, `plan.tabs.*.runs.*.run` can roughly be converted to json like this
 
 In the sections after that, some aspects are discussed in more detail.
 
-## `plan`
+## `<root>`
 
-Top-level object of a test suite.
+Root object of a test suite.
 Since this object is not named in a test suite, we ignore it in all titles below.
 
 ### `.namespace`
@@ -51,8 +55,8 @@ The default namespace is `submission`.
 For example, Java submissions must include a class called `Submission`.
 
 :::tip Hint
-The namespace is best written in `snake_case`,
-which enables using the right style convention for each programming language.
+You should use `snake_case` for the namespace,
+as it enables using the right style convention for each programming language.
 :::
 
 ## `.tabs.*`
@@ -60,7 +64,7 @@ which enables using the right style convention for each programming language.
 A list of all tabs that will be executed.
 
 The tabs in a test suite correspond with the visual grouping of test cases into tabs on Dodona.
-A tab contains a list of the runs that must be executed.
+A tab contains a list of the contexts.
 
 ### `.name`
 
@@ -70,102 +74,11 @@ The name of the tab; displayed on Dodona.
 
 A boolean indicating if the tab must be hidden when all its test cases succeed.
 
-## `.tabs.*.runs.*`
+## `.tabs.*.contexts.*`
 
-This is a list of all runs (generated executables) that must be executed.
-
-A run is a generated executable
-that contains a collection of contexts and an optional test case that evaluates the submission.
-
-## `.tabs.*.runs.*.run`
-
-The test case that executes the submission.
-It will be visualized as a separate context on Dodona.
-
-### `.input`
-
-The run input contains all information that is necessary to evaluates the written program
-(`main`-call or the code itself) by the student.
-
-#### `.input.stdin`
-
-The content that is made available on standard input.
-This can either be an ([EmptyChannel](#emptychannel)) object,
-or a [TextData](#textdata) object providing the path name of a text file or a string containing the content.
-
-#### `.input.arguments`
-
-list of string arguments that are passed when executing the submission.
-
-#### `.input.main_call`
-
-A boolean indicating if the submission must be executed. By default, the submission will not be executed.
-
-### `.output`
-
-This object contains all the necessary information to evaluate the executed submission.
-
-#### `.output.stdout`
-
-The output channel for standard output.
-Possible output channels are:
-
-- [EmptyChannel](#emptychannel) (default): No output is expected on this channel.
-  This is the default option.
-- [IgnoredChannel](#ignoredchannel): No output is expected on this channel, but generated output is ignored.
-- [TextOutputChannel](#textoutputchannel): Expected output on this channel.
-
-#### `.output.stderr`
-
-The output channel for standard error.
-Possible output channels are:
-
-- [EmptyChannel](#emptychannel) (default): No output is expected on this channel.
-  This is the default option.
-- [IgnoredChannel](#ignoredchannel): No output is expected on this channel, but generated output is ignored.
-- [TextOutputChannel](#textoutputchannel): Expected output on this channel.
-
-#### `.output.file`
-
-The output channel for a file.
-Possible output channels are:
-
-- [IgnoredChannel](#ignoredchannel) (default): No output is expected on this channel, but generated output is ignored.
-- [FileOutputChannel](#fileoutputchannel): Expected output on this channel.
-
-_**Note:**_ TESTed currently supports at most one expected file for each execution of the submission.
-Additionally, there is currently no way to check that _no_ files were generated.
-
-#### `.output.exception`
-
-The output channel for an exception.
-The possible output channels are:
-
-- [EmptyChannel](#emptychannel) (default): No exception is expected.
-- [IgnoredChannel](#ignoredchannel): No exception is expected, but any exceptions raised are ignored.
-- [ExceptionOutputChannel](#exceptionoutputchannel): Expected exception.
-
-#### `.output.exit_code`
-
-The output channel for the exit code upon termination of executing the submission.
-The exit code must be passed in the object [ExitCodeOutputChannel](#exitcodeoutputchannel).
-By default, the expected exit code is zero (0).
-
-### `.description`
-
-A description of the context as displayed by Dodona.
-When no description is given, it will be automatically generated by TESTed.
-
-### `.link_files.*`
-
-A list of files that must be linked in the feedback on Dodona (see [documentation for the contexts](#link-files-2)).
-
-## `.tabs.*.runs.*.contexts.*`
-
-A list of contexts that will be executed.
-A context is a list of dependent test cases that must be executed in succession.
-In addition to the test cases, a context can contain setup and teardown code,
-which is also described in a way that is independent of any programming language.
+A list of contexts to be executed.
+A context is a set of test cases that are executed together, and optionally depend on each other.
+For example, if you save the result of a function call in a variable and wish to use that variable later, these test cases must be in the same context.
 
 ### `.before`
 
@@ -208,22 +121,53 @@ The storage method of the content.
 Currently, the only value supported is `disk`, which is also the default value.
 This attribute is only included for legacy reasons and may become deprecated in the future.
 
-## `.tabs.*.runs.*.contexts.*.testcases.*`
+## `.tabs.*.contexts.*.testcases.*`
 
-A test case is a statement or an expression that must be executed and evaluated.
+A test case is a statement or an expression that will be executed and evaluated.
+Each context has at least one test case.
+The following two constraints apply:
+
+- Only the first test case may have a "main call", i.e. command line arguments or stdin.
+- Only the last test case may have a test for the program's exit code.
+
+Do note that the first and last test case may be the same one:
+if you only have one test case, it may be a main call and have a check for the exit code.
 
 ### `.input`
 
-A statement or expression (see [Statements and expressions](#statements-and-expressions)).
+The input for a test case can always be a statement or an expression
+(see [Statements and expressions](#statements-and-expressions)).
+
+However, if this is the first test case, the input may also be the "main" input, using the properties described below.
+If using the "main" input, at least one of the properties below is required.
+
+#### `.input.stdin`
+
+The content that is made available on standard input.
+This can either be an ([EmptyChannel](#emptychannel)) object,
+or a [TextData](#textdata) object providing the path name of a text file or a string containing the content.
+
+#### `.input.arguments`
+
+A list of string arguments that are passed when executing the submission.
+If left out, an empty list is used.
+
+#### `.input.main_call`
+
+If there is no `stdin` and there are no arguments,
+but you still want to have a "main" input, you can set this field to `True`.
 
 ### `.description`
 
-A description of the test case as displayed by Dodona.
-When no description is given, it will be automatically generated by TESTed.
+A description of the test case to be displayed by Dodona.
+When no description is given, it will be automatically generated by TESTed based on the input for this test case.
+In most cases, you will probably want to use the automatically generated description.
 
 ### `.output`
 
-An object that contains all the necessary information to evaluate a test case.
+The output object contains all tests for the given test case.
+
+Note that you can only use the test for the exit code if this is the last test case in the context.
 
 #### `.output.stdout`
 
@@ -241,7 +185,6 @@ The output channel for standard error.
 Possible output channels are:
 
 - [EmptyChannel](#emptychannel) (default): No output is expected on this channel.
-  This is the default option.
 - [IgnoredChannel](#ignoredchannel): No output is expected on this channel, but generated output is ignored.
 - [TextOutputChannel](#textoutputchannel): Expected output on this channel.
 
@@ -259,7 +202,7 @@ Additionally, there is currently no way to check that _no_ files were generated.
 #### `.output.exception`
 
 The output channel for an exception.
-The possible output channels are:
+The possible channels are:
 
 - [EmptyChannel](#emptychannel) (default): No exception is expected.
 - [IgnoredChannel](#ignoredchannel): No exception is expected, but any exceptions raised are ignored.
@@ -268,11 +211,19 @@ The possible output channels are:
 #### `.output.result`
 
 The output channel for the result of an expression.
-The possible output channels are:
+The possible channels are:
 
 - [EmptyChannel](#emptychannel) (default): No result is expected.
 - [IgnoredChannel](#ignoredchannel): No exception is expected, but any exceptions raised are ignored.
 - [ValueOutputChannel](#valueoutputchannel): The expected result of the expression.
+
+#### `.output.exit_code`
+
+The output channel for the exit code of the submission.
+The possible channels are:
+
+- [IgnoredChannel](#ignoredchannel) (default): Exit code is not checked.
+- [ExitCodeOutputChannel](#exitcodeoutputchannel): Allows you to specify the expected exit code.
 
 ## TextData
 

--- a/en/tested/json/README.md
+++ b/en/tested/json/README.md
@@ -1,19 +1,27 @@
 ---
-title: Test suite format
+title: Advanced test suite reference
 description: "Create test suites for TESTed"
 sidebarDepth: 2
 ---
 
-# Test suite format
+# Advanced test suite reference
+
+:::tip Advanced test suites vs. DSL test suites
+This is the reference guide for advanced test suites, written in JSON.
+In most cases, you should prefer using the DSL test suites (written in YAML).
+
+This format is mostly useful if:
+- You generate the test suite programmatically. In this case, JSON might be easier than YAML to write.
+- You need to do something that is not supported by the DSL test suite format.
+:::
 
 In TESTed, a test suite specifies which test cases are executed against a submission.
 TESTed differs from other test frameworks in that its test suites are independent of any programming language.
-As a result, a single test suite is sufficient to check submissions for the same exercise in different programming
-languages.
+As a result,
+a single test suite is sufficient to check submissions for the same exercise in different programming languages.
 
-The TESTed test suite format is formally specified
-by [this Python module](https://github.com/dodona-edu/universal-judge/blob/master/tested/testplan.py).
-It can also generate a JSON Schema to make the validation of test suites easier.
+[This Python module](https://github.com/dodona-edu/universal-judge/blob/master/tested/testplan.py) formally specifies the TESTed test suite format.
+The module can also generate a JSON Schema to make the validation of test suites easier.
 The [source code repository](https://github.com/dodona-edu/universal-judge/tree/master/exercise) for TESTed contains a number of examples of test suites.
 
 The first section of this reference describes the structure of the test suite.

--- a/nl/tested/README.md
+++ b/nl/tested/README.md
@@ -40,7 +40,7 @@ Als u TESTed wenst te gebruiken buiten Dodona, raden we aan [deze handleiding](h
 Een aantal technische specificaties zijn ook beschikbaar:
 
 - [Configuratie-opties](/nl/tested/exercise-config)
-- [Formaat voor testplannen](/nl/tested/json)
+- [Formaat voor geavanceerde testplannen (JSON)](/nl/tested/json) (niet aanbevolen voor algemeen gebruik)
 - [Gegevenstypes voor programmeertalen](/nl/tested/types)
 
 Nuttige handleidingen als u aan TESTed zelf wilt werken:
@@ -173,7 +173,7 @@ Maak een nieuw bestand `config.json` aan in de map `echo`, met volgende inhoud:
     }
   },
   "evaluation": {
-    "plan_name": "tests.json"
+    "plan_name": "tests.yaml"
   },
   "programming_language": "python",
   "access": "private"
@@ -183,7 +183,7 @@ Maak een nieuw bestand `config.json` aan in de map `echo`, met volgende inhoud:
 Dit configuratiebestand specifieert, in volgorde:
 
 1. Een naam voor de oefening in het Nederlands en het Engels.
-2. Het pad naar het testplan (`tests.json`), relatief ten opzichte van de map `echo/evaluation`.
+2. Het pad naar het testplan (`tests.yaml`), relatief ten opzichte van de map `echo/evaluation`.
 3. We stellen de standaardprogrammeetaal in op Python.
    Hoewel TESTed meerdere programmeertalen ondersteunt,
    is Dodona beperkt tot één programmeertaal per oefening.
@@ -234,52 +234,20 @@ Een testplan bevat alle testgevallen die uitgevoerd zullen worden op een oplossi
 
 Om deze handleiding kort te houden, beperken we ons tot een testplan met één enkel testgeval.
 In een echte oefening zou het testplan veel meer testgevallen bevatten.
-Maak een nieuw bestand `evaluation/tests.json` met volgende inhoud:
+Maak een nieuw bestand `evaluation/tests.yaml` met volgende inhoud:
 
-```json
-{
- "tabs": [
-  {
-   "name": "Echo",
-   "runs": [
-    {
-     "contexts": [
-      {
-       "testcases": [
-        {
-         "input": {
-          "type": "function",
-          "name": "echo",
-          "arguments": [
-           {
-            "type": "text",
-            "data": "input-1"
-           }
-          ]
-         },
-         "output": {
-          "stdout": {
-           "type": "text",
-           "data": "input-1"
-          }
-         }
-        }
-       ]
-      }
-     ]
-    }
-   ]
-  }
- ]
-}
+```yaml
+- tab: "Echo"
+  testcases:
+     - expression: "echo('input-1')"
+       stdout: "input-1"
 ```
 
 Dit testplan definieert zegt:
 
 1. Alle feedback is verzameld in één tabblad met naam _Echo_.
 2. Het tabblad bevat feedback voor één testgeval.
-3. Het testgeval roept we de functie `echo` op met een string `input-1` als argument.
-   Conceptueel is dit equivalent met `echo("input-1")` uitvoeren in Python.
+3. Het testgeval roept we de functie `echo` op met een string `"input-1"` als argument.
 4. Het verwachte resultaat is dat de tekst `input-1` op stdout geschreven wordt.
 
 Nu ziet de bestandsstructuur er als volgt uit:
@@ -288,7 +256,7 @@ Nu ziet de bestandsstructuur er als volgt uit:
 ├── echo/
 |   ├── config.json
 |   ├── evaluation/
-|   |   └── tests.json
+|   |   └── tests.yaml
 |   ├── description/
 |   |   └── description.nl.md
 ```

--- a/nl/tested/README.md
+++ b/nl/tested/README.md
@@ -40,7 +40,8 @@ Als u TESTed wenst te gebruiken buiten Dodona, raden we aan [deze handleiding](h
 Een aantal technische specificaties zijn ook beschikbaar:
 
 - [Configuratie-opties](/nl/tested/exercise-config)
-- [Formaat voor geavanceerde testplannen (JSON)](/nl/tested/json) (niet aanbevolen voor algemeen gebruik)
+- [Referentie voor DSL-testplannen](/nl/tested/dsl) (aanbevolen)
+- [Referentie voor geavanceerde testplannen](/en/tested/json) (niet aanbevolen voor algemeen gebruik)
 - [Gegevenstypes voor programmeertalen](/nl/tested/types)
 
 Nuttige handleidingen als u aan TESTed zelf wilt werken:

--- a/nl/tested/dsl/README.md
+++ b/nl/tested/dsl/README.md
@@ -1,0 +1,400 @@
+---
+title: Referentie voor DSL-testplannen
+description: "Schrijf eenvoudig testplannen voor TESTed"
+sidebarDepth: 2
+---
+
+# Referentie voor DSL-testplannen
+
+Een testplan voor TESTed legt vast welke testgevallen uitgevoerd worden op een ingediende oplossing.
+TESTed verschilt van andere judges doordat testplannen niet afhankelijk zijn van één bepaalde programmeertaal.
+Derhalve volstaat één testplan om ingediende oplossingen in verschillende programmeertalen van dezelfde oefening te evalueren.
+
+Naast het [geavanceerde formaat](/nl/tested/json) voor testplannen hebben we ook een kleine domeinspecifieke taal (_domain-specific language_, DSL) ontwikkeld om het schrijven van testplannen makkelijker te maken.
+Dit document is de referentiegids voor het formaat van DSL-testplannen en bevat alle opties en mogelijkheden.
+
+[//]: # (We hebben ook een reeks tutorials waar we uitleggen hoe een bepaalde soort oefening opgesteld moet worden.)
+
+DSL-testplannen worden geschreven in YAML.
+Een JSON Schema van het formaat is beschikbaar in de repository van TESTed.
+Dit schema kan zorgen voor automatische controles en automatisch aanvullen in uw tekstverwerker.
+
+## Structuur en opbouw
+
+De structuur van een DSL-testplan volgt de algemene structuur van testen in Dodona, en bestaat uit drie niveaus:
+
+1. [Tabs](#tabs)
+2. [Contexten](#contexten)
+3. [Testgevallen](#testgevallen)
+
+In de rest van de paragraaf beschrijven we elk niveau.
+Verplichte attributen worden aangeduid met een ster (*).
+Op het [eind van dit document](#volledig-voorbeeld) staat een volledig voorbeeld.
+
+### Top van het testplan
+
+Een testplan start met ofwel een lijst van [tabs](#tabs), ofwel een object.
+Dat object heeft drie attributen:
+
+- `tabs`*: een lijst van [tab](#tabs)-objecten
+- `namespace`: de "namespace" voor de code van de ingediende oplossing, zoals de klassennaam in Java.
+- `config`: de globale [configuratieopties](#configuratieopties)
+
+### Tabs
+
+Een tab-object komt overeen met een tab in de uitvoer op Dodona.
+Het heeft vier mogelijke attributen:
+
+- `tab`*: de naam van de tab die getoond wordt in Dodona
+- `contexts`*: een lijst van [contexten](#contexten) (als dit gebruikt wordt, mag het attribuut `testcases` niet
+  gebruikt worden)
+- `testcases`*: een lijst van [testgevallen](#testgevallen) (als dit gebruikt wordt, mag het attribuut `contexts` niet
+  gebruikt worden)
+- `config`: de [configuratieopties](#configuratieopties) voor deze tab en al zijn kinderen
+
+In veel oefeningen is er precies een testgeval per context.
+Dat is exact wat het attribuut `testcases` toelaat: achter de schermen zal elk testgeval in een eigen context geplaatst worden.
+
+:::tip Hint
+Hoewel er vier mogelijke attributen zijn, zal elk tab-object hoogstens drie attributen hebben, want `contexts` en `testcases` kunnen niet samen gebruikt worden.
+:::
+
+### Contexten
+
+Een context is een groep testgevallen die afhankelijk zijn van elkaar.
+Het context-object heeft drie attributen:
+
+- `testcases`*: een lijst van [testgevallen](#testgevallen)
+- `config`: de [configuratieopties](#configuratieopties) voor deze context en al zijn kinderen
+- `context`: een optionele beschrijving van de context
+- `files`: een optionele lijst van [bestanden](#bestanden)
+
+In de meeste gevallen is aangewezen om de beschrijving leeg te laten.
+
+Elke context heeft minstens één testgeval.
+Omdat elke context apart wordt uitgevoerd, zijn de volgende beperkingen van toepassing:
+
+- Enkel het eerste testgeval mag de "_main
+  call_" bevatten, bijvoorbeeld met argumenten voor de commandoregel of standaardinvoer.
+- Enkel het laatste testgeval met de test bevatten voor de exitcode.
+
+Merk op dat het eerste en laatste testgeval wel hetzelfde testgeval kunnen zijn:
+als er maar een testgeval is, kan het zowel de _main call_ als de test voor de exitcode bevatten.
+
+### Testgevallen
+
+Testgevallen zijn de bouwstenen van een testplannen, en bevatten de invoer en de verwachte uitvoer (de _testen_).
+Binnen dezelfde context zijn de volgende beperkingen van toepassing:
+
+- Enkel het eerste testgeval mag de "_main
+  call_" bevatten, bijvoorbeeld met argumenten voor de commandoregel of standaardinvoer.
+- Enkel het laatste testgeval met de test bevatten voor de exitcode.
+
+Merk op dat het eerste en laatste testgeval wel hetzelfde testgeval kunnen zijn:
+als er maar een testgeval is, kan het zowel de _main call_ als de test voor de exitcode bevatten.
+
+Een testgeval-object kan de volgende attributen hebben:
+
+- `config`: de [configuratieopties](#configuratieopties) voor dit testgeval en al zijn kinderen
+- `files`: een optionele lijst van [bestanden](#bestanden)
+
+Daarnaast kan een testgeval ook de attributen die hieronder beschreven worden hebben, maar merk op:
+
+- Een testgeval kan slechts één "invoer" hebben, wat betekent dat de attributen `arguments`/`stdin`, `expression` en `statement` niet tegelijk gebruikt kunnen worden.
+- De attributen `return` en `return_raw` kunnen niet tegelijk gebruikt worden, want er kan slechts één returnwaarde per expressie zijn.
+- De attributen `return`/`return_raw` vereisen ofwel het attribuut `expression` ofwel `statement`.
+
+#### `stdin`
+
+De gegevens voor [standaardinvoer](https://nl.wikipedia.org/wiki/Standaardstromen).
+
+Als dit attribuut gebruikt wordt, kunnen `expression` en `statement` niet meer gebruikt worden als invoer,
+noch kunnen `return` of `return_raw` als test gebruikt worden.
+
+#### `arguments`
+
+Een lijst van strings die als argumenten via de [commandoregel](https://nl.wikipedia.org/wiki/Command-line-interface) aan het programma doorgegeven worden.
+
+Als dit attribuut gebruikt wordt, kunnen `expression` en `statement` niet meer gebruikt worden als invoer,
+noch kunnen `return` of `return_raw` als test gebruikt worden.
+
+#### `main_call`
+
+Een optioneel attribuut dat op `true` gezet kan worden als er een _main call_ moet zijn zonder stdin of argumenten.
+
+Als dit attribuut gebruikt wordt, kunnen `expression` en `statement` niet meer gebruikt worden als invoer,
+noch kunnen `return` of `return_raw` als test gebruikt worden.
+
+#### `expression` / `statement`
+
+Bevat de te evalueren expressie of het uit te voeren statement in dit testgeval.
+Deze attributen zijn synoniemen.
+
+Expressies en statements gebruiken de syntaxis van Python, met een aantal beperkingen, die we [hier](#expressies-en-statements) beschrijven.
+
+#### `stdout` / `stderr`
+
+Specifieert het verwachte resultaat op respectievelijk standaarduitvoer (stdout) en standaardfout (stderr).
+
+De waarde van het attribuut is ofwel een string (dat dan het verwachte resultaat is), of een object voor meer complexe situaties.
+Het object heeft volgende attributen:
+
+- `data`: het verwachte resultaat, zoals bij het gebruik van een string
+- `config`: the [configuratieopties](#testopties)
+
+#### `exception`
+
+Specifieert het verwachte bericht van een verwachte uitzondering of fout (een _exception_).
+Merk op dat TESTed momenteel niet kan oordelen over het soort of type van de fout.
+Het is bijvoorbeeld niet mogelijk om te controleren of een _assertion error_ gebruikt is.
+
+#### `return` / `return_raw`
+
+Specifieert de verwachte returnwaarde.
+In de meeste gevallen is het beter om `return` te gebruiken, waarbij de verwachte waarde als een YAML-waarde genoteerd wordt (string, getal, boolean, enz.).
+Voor meer geavanceerde waarden is gebruik van `return_raw` mogelijk,
+dat toelaat om dezelfde Python-syntaxis te gebruiken als voor de [expressies en statements](#expressies-en-statements),
+met de beperking dat alleen waarden toegelaten zijn.
+Een returnwaarde kan bijvoorbeeld geen funtieoproep zijn.
+
+Zoals al vermeld zijn deze attributen enkel toegelaten als `expression` of `statement` als invoer voor het testgeval gebruikt is.
+De attributen `return` en `return_raw` kunnen ook niet tegelijk gebruikt worden.
+
+#### `exit_code`
+
+Specifieert de verwachte exitcode van het programma.
+
+Enkel het laatste testgeval in een context kan dit attribuut hebben, maar het laatste testgeval kan ook het eerste zijn als er maar één testgeval is.
+
+### Bestanden
+
+Soms zijn parameters of andere strings de naam van een bestand.
+Als die bestanden een snelkoppeling naar het eigenlijke bestand moeten worden, dan moet er een lijst van bestanden meegegeven worden.
+Elk object in die lijst heeft twee attributen:
+
+- `name`: de naam van het bestand zoals het voorkomt in de invoer
+- `url`: de locatie waar de snelkoppeling naar moet wijzen, relatief ten opzicht van de map van de oefening.
+
+## Configuratieopties
+
+Het configuratie-object kan op elk niveau gebruikt worden en zal ook van toepassing zijn op alle onderliggende niveaus.
+Een configuratie-object op tabniveau gebruiken zal er bijvoorbeeld voor zorgen dat die configuratie ook van toepassing is op alle contexten, en uiteindelijk ook op alle testgevallen in die tab.
+
+Een configuratie-object kan volgende attributen hebben:
+
+- `stdout`: de [configuratieopties](#testopties) voor standaarduitvoer (stdout)
+- `stderr`: de [configuratieopties](#testopties) voor standaardfout (stderr)
+- `return`: de [configuratieopties](#testopties) voor de verwachte returnwaarde
+
+### Testopties
+
+Dit object bevat een aantal configuratieopties die invloed hebben op hoe de testresultaten beoordeeld worden door TESTed.
+De volgende opties zijn beschikbaar:
+
+- `applyRounding`: pas afronding toe als waarden als vlottendekommagetal vergeleken worden
+- `roundTo`: het aantal cijfers om op af te ronden, als `applyRouding` gebruikt wordt
+- `caseInsensitive`: negeer hoofdletters en kleine letters bij het vergelijken van strings
+- `ignoreWhitespace`: negeer witruimte aan het begin en einde
+- `tryFloatingPoint`: probeer tekst eerst als vlottendekommagetal te vergelijken
+
+## Expressies en statements
+
+In een testplan worden expressies en statements als YAML-strings geschreven, gebruik makende van de syntaxis van Python.
+Een functieoproep met het argument `"hello"` wordt bijvoorbeeld:
+
+```yaml
+expression: "a_function_name('hello')"
+```
+
+Aangezien de syntaxis van Python voor een aantal zaken van TESTed geen aparte syntaxis heeft, zijn er aantal conventies:
+
+- Functieoproepen vier naam begint met een hoofdletters worden beschouwd als
+  _constructors_, bijvoorbeeld `Constructor(56)`.
+- Identifiers die volledig in hoofdletters geschreven zijn worden beschouwd als globale constanten, bijvoorbeeld `VERY_LONG_NAME`.
+- Het casten van waarden gebeurt op de gebruikelijke manier van Python. Het casten van een getal naar `int64` wordt bijvoorbeeld `int64(56)`.
+
+Bijkomend worden grote delen van de syntaxis niet ondersteund, daar TESTed enkel beperkte ondersteuning heeft voor expressies en statements.
+Volgende zaken worden ondersteund:
+
+- Eenvoudige waarden, zoals `5`, `-9.3` of `"Hello world"`.
+- Complexe waarden, zoals `[5, 6, 7]`, `{5, "Hello"}` of `{"key": "value"}`.
+- Functieoproepen, inclusief _named parameters_, zoals `the_function(5, named=6)`.
+  Merk op dat de _named
+  parameters_ omgezet worden naar normale parameters op basis van hun positie in programmeertalen die geen ondersteuning hebben voor
+  _named parameters_.
+- Constructors (middels onze conventie).
+- Declareren en toewijzen van variabelen (_assignments_), zoals `some_variable = 5`.
+- Refereren naar variabelen, zoals `the_function(some_variable)`.
+
+Noemenswaardige weglatingen zijn alle soorten van functie- of klassendefinities, alsook alle operatoren.
+
+## Spiekbriefje voor YAML
+
+Deze paragraaf bevat een heel kort overzicht van het deel van functionaliteit van YAML die we gebruiken in de DSL.
+
+### Objecten
+
+Objecten in YAML zijn sleutel-waardeparen, waarbij de sleutel (het attribuut) en de waarde gescheiden worden door een dubbelpunt:
+
+```yaml
+key: value
+```
+
+Geneste objecten worden aangeduid door een insprong:
+
+```yaml
+root:
+  child0:
+    subchild0: "leaf"
+    subchild1: "leaf"
+  child1:
+    subchild0: "leaf"
+```
+
+### Lijsten
+
+Lijsten kunnen in YAML geschreven worden ofwel op één regel (gebruik makende van de JSON-syntaxis) ofwel met een waarde per regel.
+Bijvoorbeeld, een lijst op een regel:
+
+```yaml
+[ "Item 0", "Item 1", "Item 2", "Item 3" ]
+```
+
+Bij de notatie van één waarde per regel moet elke regel voorafgegaan worden door een liggend streepje (-) en spatie:
+
+```yaml
+- "Item 0"
+- "Item 1"
+- "Item 2"
+- "Item 3"
+```
+
+Lijsten en objecten kunnen ook gecombineerd worden:
+
+```yaml
+list:
+  - name: "Item 0"
+    items: 5
+  - name: "Item 1"
+  - name: "Item 2"
+    items: 3
+  - name: "Item 3"
+```
+
+### Strings
+
+Gewone strings worden in YAML geschreven tussen dubbele aanhalingstekens:
+
+```yaml
+description: "Hello"
+```
+
+Een string met regeleindes wordt op dergelijke wijze nogal lelijk:
+
+```yaml
+description: "Hello\nWorld"
+```
+
+YAML ondersteunt een speciale notatie voor strings met regeleindes.
+Dezelfde string als het laatste voorbeeld geschreven in die notatie wordt dan:
+
+```yaml
+description: |
+  Hello
+  World
+```
+
+Het omgekeerde is ook mogelijk, namelijk de "gevouwen strings" (_folded strings_).
+Bij deze notatie zal YAML de regeleindes verwijderen:
+
+```yaml
+description: >
+  Hello
+  World
+```
+
+Dit is equivalent aan:
+
+```yaml
+description: "Hello World"
+```
+
+## Volledig voorbeeld
+
+Hieronder staat een testplan waar alle opties gebruikt worden:
+
+```yaml
+# Een tab op Dodona.
+- tab: "Naam van de tab"
+  contexts:
+    # De bestanden gebruikt in deze context.
+    - files:
+        - name: "file.txt"
+          url: "media/workdir/file.txt"
+      testcases:
+        # Een assignment van de variable "data".
+        - statement: 'data = ["list\nline", "file.txt"]'
+          # Functieoproep waarbij de variabele gebruikt wordt.
+        - statement: 'function(data, 0.5)'
+          # Verwachte returnwaarde van die functie.
+          return: [ 0, 0 ]
+    - testcases:
+        # Een functieoproep waarbij de waarde gecast wordt naar "uint8".
+        - statement: 'echo(uint8(5))'
+          # De verwachte returnwaarde wordt ook gecast naar "uint8".
+          return_raw: "uint8(5)"
+
+# Een tweede tab in hetzelfde testplan.
+- tab: "Exception"
+  contexts:
+    - testcases:
+        # Opnieuw een functieoproep.
+        - statement: 'function_error()'
+          # De verwachte tekst op stdout.
+          stdout: "Invalid"
+          # De verwachte tekst op stderr.
+          stderr: "Error"
+          # We verwachten ook een fout of exception met de boodschap "Unknown".
+          exception: "Unknown"
+
+# Een derde tab.
+- tab: "Arguments"
+  testcases:
+    # Dit programma krijgt invoer mee via stdin
+    - stdin: "Alice"
+      # Er zijn ook argumenten voor de commandoregel.
+      arguments: [ "stdin" ]
+      # We verwachten deze tekst op stdout.
+      stdout: "Hello Alice"
+
+# Een vierde tab.
+- tab: "Config"
+  # We configureren alles op het niveau van de tab.
+  config:
+    stdout:
+      # Tekst op stdout proberen we eerst als getal te vergelijken.
+      tryFloatingPoint: true
+      # Als we een getal vergelijken, ronden we af op 2 cijfers.
+      applyRounding: true
+      roundTo: 2
+    # Op stderr negeren we witruimte en
+    # het verschil met hoofdletters en kleine letters
+    stderr:
+      ignoreWhitespace: true
+      caseInsensitive: true
+  contexts:
+    - config:
+        stdout:
+          # In deze context overschrijven de configuratie van de tab.
+          roundTo: 0
+      testcases:
+        - statement: 'diff(5, 2)'
+          stdout: "2"
+        - statement: 'diff(5, 2)'
+          stdout:
+            data: "2.5"
+            # In deze test overschrijven we de configuratie van de context.
+            config:
+              roundTo: 4
+
+```

--- a/nl/tested/exercise-config/README.md
+++ b/nl/tested/exercise-config/README.md
@@ -9,13 +9,12 @@ Naast de [algemene configuratieopties](/nl/references/exercise-config) voor oefe
 
 ## Testplan
 
-De standaardlocatie van een testplan voor TESTed is een JSON-bestand `plan.json` in de map `evaluation` van de oefening.
-Het optionele veld `testplan` in het `evaluation`-blok kan gebruikt worden om een alternatieve locatie in te stellen, relatief tegenover de map `evaluation`.
+Het veld `test_suite` in het `evaluation`-blok wordt gebruikt om de locatie van het testplan op te geven, relatief tegenover de map `evaluation`.
 
 ```json
 {
   "evaluation": {
-    "testplan": "plan.json"
+    "test_suite": "suite.yaml"
   }
 }
 ```

--- a/nl/tested/json/README.md
+++ b/nl/tested/json/README.md
@@ -1,18 +1,20 @@
 ---
-title: "[en] Formaat voor testplannen"
-description: "Maak testplannen voor TESTed"
+title: "[en] Referentie voor geavanceerde testplannen"
+description: "Schrijf geavanceerde testplannen voor TESTed"
 ---
-# Formaat voor testplannen
+# Referentie voor geavanceerde testplannen
 
-::: warning Engelstalige referentie
-De volledige referentie is enkel beschikbaar in het Engels.
+:::warning Geavanceerde testplannen vs. DSL-testplannen
+Dit is de referentiegids voor geavanceerde testplannen, geschreven in JSON.
+In de meeste gevallen is het beter om de [DSL-testplannen](/nl/tested/dsl) (geschreven in YAML) te gebruiken.
+
+Het geavanceerde formaat kan nuttig zijn om:
+
+- Het testplan te genereren met code. In dat geval kan het makkelijker zijn om JSON te genereren dan YAML.
+- Iets te doen dat de DSL-testplannen niet ondersteunen.
+
+Merk ook op dat deze referentie enkel in het Engels beschikbaar is.
 [Ga naar de Engelstalige versie.](/en/tested/json)
 :::
 
-Een testplan voor TESTed legt vast welke testgevallen uitgevoerd worden op een ingediende oplossing.
-TESTed verschilt van andere judges doordat testplannen niet afhankelijk zijn van één bepaalde programmeertaal.
-Derhalve volstaat één testplan om ingediende oplossingen in verschillende programmeertalen van dezelfde oefening te evalueren.
-
-Het formaat voor testplannen voor TESTed is formeel vastgelegd door [deze Python-module](https://github.com/dodona-edu/universal-judge/blob/master/tested/testplan.py).
-Deze module kan ook een _JSON Schema_ genereren om het valideren van testplannen makkelijker te maken.
-The [repository met de broncode](https://github.com/dodona-edu/universal-judge/tree/master/exercise) van TESTed bevat een aantal voorbeelden van testplannen.
+[Ga naar de Engelstalige versie.](/en/tested/json)


### PR DESCRIPTION
- Updates reference documentation for advanced test suites to remove "runs".
- Add reference documentation for DSL test suites.
- Use or reference the DSL instead of the advanced test suites.
- Add warning that people should use the DSL instead of the advanced test suites.

(this is only reference documentation, no tutorials)