### PR TITLE
Override more colours

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -1,12 +1,24 @@
 /* https://vitepress.dev/guide/extending-default-theme#customizing-css */
 
 :root {
-    --vp-c-brand: #0061a6;
+    --vp-c-brand: #0061A6;
+    --vp-c-brand-light: #1E95F2;
+    --vp-c-brand-lighter: #9CCAFF;
+    --vp-c-brand-dark: #00497F;
+    --vp-c-brand-darker: #00325A;
 }
 
 /* Using prefers-color-scheme does not work with the selector */
 .dark {
-    --vp-c-brand: #9ccaff;
+    --vp-c-brand: #9CCAFF;
+    --vp-c-brand-light: #E8F1FF;
+    --vp-c-brand-lighter: #FCFCFF;
+    --vp-c-brand-dark: #00497F;
+    --vp-c-brand-darker: #00325A;
+
+    /* Override the colour of button text because our background is light */
+    --vp-button-brand-text: var(--vp-c-black);
+    --docsearch-hit-active-color: var(--vp-c-black);
 }
 
 /* Medium zoom */


### PR DESCRIPTION
- All theme colours are now overridden, no more green
- Override some specifics in dark mode to improve contrast

The colours were taken bij choosing our primary colour in the MD colours and going lighter or darker for the variants.

Before:
![image](https://github.com/dodona-edu/dodona-edu.github.io/assets/1756811/2cb2647e-be64-4b89-9f1d-2a3f82a6b741)
![image](https://github.com/dodona-edu/dodona-edu.github.io/assets/1756811/39f9e180-883c-41eb-a1f2-6589b95d8296)

After:
![image](https://github.com/dodona-edu/dodona-edu.github.io/assets/1756811/8b6a140f-c2e0-4b39-a26d-21f95cf54870)
![image](https://github.com/dodona-edu/dodona-edu.github.io/assets/1756811/98db764f-2a85-4865-bcc4-0899f452ca44)

Fixes #251.