### PR TITLE
Add external link icon for news on home page

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -19,13 +19,14 @@ hero:
       link: https://dodona.ugent.be
 
 features:
-  - title: News
-    details: Release notes and the latest news on Dodona.
-    link: https://github.com/orgs/dodona-edu/discussions?discussions_q=category%3AAnnouncements+category%3A%22Release+notes%22
   - title: Guides
     details: Manuals on getting things done with Dodona.
     link: /en/guides/general/getting-started/
   - title: References
     details: Technical references on config files and directory structures.
     link: /en/references/
+  - title: News
+    details: Release notes and the latest news on Dodona.
+    link: https://github.com/orgs/dodona-edu/discussions?discussions_q=category%3AAnnouncements+category%3A%22Release+notes%22
+    linkText: View on GitHub
 ---

--- a/nl/index.md
+++ b/nl/index.md
@@ -19,13 +19,14 @@ hero:
       link: https://dodona.ugent.be
 
 features:
-  - title: Nieuws
-    details: Release notes en het laatste nieuws over Dodona.
-    link: https://github.com/orgs/dodona-edu/discussions?discussions_q=category%3AAnnouncements+category%3A%22Release+notes%22
   - title: Handleidingen
     details: Handleidingen en info over hoe je Dodona kan gebruiken.
     link: /nl/guides/general/getting-started/
   - title: Referenties
     details: Technische referentie over configuraties en mappenstructuren.
     link: /nl/references/
+  - title: Nieuws
+    details: Release notes en het laatste nieuws over Dodona.
+    link: https://github.com/orgs/dodona-edu/discussions?discussions_q=category%3AAnnouncements+category%3A%22Release+notes%22
+    linkText: Bekijk op GitHub
 ---


### PR DESCRIPTION
This change makes it clearer that the news link will take the user to an external website:
![image](https://github.com/dodona-edu/dodona-edu.github.io/assets/481872/05b83980-1c70-46b5-ae4d-7323f3100d18)
