### PR TITLE
Add FAQ about API

### DIFF
--- a/en/faq/api-tokens/index.md
+++ b/en/faq/api-tokens/index.md
@@ -50,7 +50,7 @@ In Python, this would look like:
 #!/usr/bin/python3
 # Name: Get submissions
 # By Robbert Gurdeep Singh
-################################################################################
+######################################################################
 TOKEN = "TOKEN HERE"
 
 
@@ -62,9 +62,7 @@ headers = {
     "Authorization" : TOKEN
 }
 
-conn.request("GET",
-    "/nl/submissions.json",
-    headers=headers)
+conn.request("GET", "/en/submissions.json", headers=headers)
 res = conn.getresponse()
 print(res.status, res.reason)
 data = res.read()

--- a/en/faq/api-tokens/index.md
+++ b/en/faq/api-tokens/index.md
@@ -1,5 +1,5 @@
 ---
-title: API tokens
+title: API and API tokens
 ---
 
 # FAQ: API tokens
@@ -26,3 +26,48 @@ Follow the steps below to create an API token on Dodona:
 ::: tip
 Please note that for security reasons you will not be able to view the tokens on Dodona after creation. However, you can see a list of all your active tokens. You can delete a token at any time and it will stop working immediately.
 :::
+
+## How can I use the Dodona API?
+
+::: warning
+If you want to build an application, tool or plugin that uses the Dodona API, please contact us at [dodona@ugent.be](mailto:dodona@ugent.be) so we can help you out. This will also allow us to notify you if we make any changes to the API.
+:::
+
+Many of the actions you can perform on Dodona can also be done through the API. Unfortunately, we do not have a complete documentation of the API yet. The easiest way to check if a certain action is possible through the API is to add `.json` to the end of the URL. For example, if you want to get a list of all the featured courses on Dodona, you can go to [dodona.ugent.be/courses.json?tab=featured](https://dodona.ugent.be/courses.json?tab=featured). This will return a JSON object with all the featured courses on Dodona.
+
+For endpoints where you need to be signed in, you can use an [API token](#what-is-an-api-token) to authenticate. You can do this by adding the token to an `Authorization` header with your request:
+
+```bash
+curl \
+  -H "Authorization: {YOUR TOKEN}" \
+  -H "Accept: application/json" \
+  "https://dodona.ugent.be/nl/submissions.json"
+```
+
+In Python, this would look like:
+
+```python
+#!/usr/bin/python3
+# Name: Get submissions
+# By Robbert Gurdeep Singh
+################################################################################
+TOKEN = "TOKEN HERE"
+
+
+import http.client
+conn = http.client.HTTPSConnection("dodona.ugent.be")
+headers = {
+    "Content-type": "application/json",
+    "Accept": "application/json",
+    "Authorization" : TOKEN
+}
+
+conn.request("GET",
+    "/nl/submissions.json",
+    headers=headers)
+res = conn.getresponse()
+print(res.status, res.reason)
+data = res.read()
+conn.close()
+print(data)
+```

--- a/en/faq/index.md
+++ b/en/faq/index.md
@@ -5,9 +5,10 @@ title: Frequently Asked Questions
 
 In this FAQ section you will find answers to the most frequently asked questions about using Dodona. Whether you're a student trying to understand how to navigate through lessons, a teacher setting up a new course, or just curious about certain features, we've got you covered. To find a specific page, our search function in the top navigation bar is really powerful. If you can't find the answer to your question, don't hesitate to contact [our support team](https://dodona.be/en/contact).
 
-## API tokens
+## API and API tokens
 - [What is an API token?](./api-tokens/#what-is-an-api-token)
 - [How do I create an API token?](./api-tokens/#how-do-i-create-an-api-token)
+- [How can I use the Dodona API?](./api-tokens/#how-can-i-use-the-dodona-api)
 
 ## Featured courses
 - [What is a featured courses?](./featured-courses/#what-is-a-featured-course)

--- a/nl/faq/api-tokens/index.md
+++ b/nl/faq/api-tokens/index.md
@@ -44,13 +44,13 @@ curl \
   "https://dodona.ugent.be/nl/submissions.json"
 ```
 
-In Python, ziet dit er als volgt uit:
+In Python ziet dit er als volgt uit:
 
 ```python
 #!/usr/bin/python3
 # Name: Get submissions
 # By Robbert Gurdeep Singh
-################################################################################
+######################################################################
 TOKEN = "TOKEN HERE"
 
 
@@ -62,9 +62,7 @@ headers = {
     "Authorization" : TOKEN
 }
 
-conn.request("GET",
-    "/nl/submissions.json",
-    headers=headers)
+conn.request("GET", "/nl/submissions.json", headers=headers)
 res = conn.getresponse()
 print(res.status, res.reason)
 data = res.read()

--- a/nl/faq/api-tokens/index.md
+++ b/nl/faq/api-tokens/index.md
@@ -1,8 +1,8 @@
 ---
-title: API tokens
+title: API en API tokens
 ---
 
-# FAQ: API tokens
+# FAQ: API en API tokens
 
 [[toc]]
 
@@ -26,3 +26,48 @@ Volg de onderstaande stappen om een API token aan te maken op Dodona:
 ::: tip
 Houd er rekening mee dat je om veiligheidsredenen de tokens niet kunt bekijken op Dodona nadat ze zijn aangemaakt. Je kunt echter wel een lijst van al je actieve tokens bekijken. Je kunt een token op elk moment verwijderen en het zal onmiddellijk stoppen met werken.
 :::
+
+## Hoe kan ik de Dodona API gebruiken?
+
+::: warning
+Als je een applicatie, tool of plugin wilt bouwen die de Dodona API gebruikt, neem dan contact met ons op via [dodona@ugent.be](mailto:dodona@ugent.be) zodat we je kunnen helpen. Zo kunnen we je ook op de hoogte brengen als we de API wijzigen.
+:::
+
+Veel van de acties die je kunt uitvoeren op Dodona kunnen ook worden gedaan via de API. Helaas hebben we nog geen volledige documentatie van de API. De eenvoudigste manier om te controleren of een bepaalde actie mogelijk is via de API is door `.json` toe te voegen aan het einde van de URL. Als je bijvoorbeeld een lijst wilt van alle uitgelichte cursussen op Dodona, kun je naar [dodona.ugent.be/courses.json?tab=featured](https://dodona.ugent.be/courses.json?tab=featured) gaan. Dit geeft een JSON-object met alle uitgelichte cursussen op Dodona.
+
+Voor endpoints waar je voor ingelogd moet zijn, kan je een [API token](#wat-is-een-api-token) gebruiken om je te authenticeren. Dit kan je doen door het token toe te voegen aan een `Authorization` header bij je request:
+
+```bash
+curl \
+  -H "Authorization: {YOUR TOKEN}" \
+  -H "Accept: application/json" \
+  "https://dodona.ugent.be/nl/submissions.json"
+```
+
+In Python, ziet dit er als volgt uit:
+
+```python
+#!/usr/bin/python3
+# Name: Get submissions
+# By Robbert Gurdeep Singh
+################################################################################
+TOKEN = "TOKEN HERE"
+
+
+import http.client
+conn = http.client.HTTPSConnection("dodona.ugent.be")
+headers = {
+    "Content-type": "application/json",
+    "Accept": "application/json",
+    "Authorization" : TOKEN
+}
+
+conn.request("GET",
+    "/nl/submissions.json",
+    headers=headers)
+res = conn.getresponse()
+print(res.status, res.reason)
+data = res.read()
+conn.close()
+print(data)
+```

--- a/nl/faq/index.md
+++ b/nl/faq/index.md
@@ -9,6 +9,7 @@ In deze FAQ-sectie vind je antwoorden op de meest gestelde vragen over het gebru
 ## API tokens
 - [Wat is een API token?](./api-tokens/#wat-is-een-api-token)
 - [Hoe maak ik een API token aan?](./api-tokens/#hoe-maak-ik-een-api-token-aan)
+- [Hoe kan ik de Dodona API gebruiken?](./api-tokens/#hoe-kan-ik-de-dodona-api-gebruiken)
 
 ## IDE plugins
 - [Wat is een IDE plugin?](./ide-plugins/#wat-is-een-ide-plugin)

--- a/nl/faq/index.md
+++ b/nl/faq/index.md
@@ -6,7 +6,7 @@ title: Frequently Asked Questions
 In deze FAQ-sectie vind je antwoorden op de meest gestelde vragen over het gebruik van Dodona. Of je nu een leerling bent die probeert te begrijpen hoe je door de lessen moet navigeren, een docent die een nieuwe cursus opzet of gewoon nieuwsgierig bent naar bepaalde functies, wij hebben het voor je geregeld. Om een specifieke pagina te vinden, is onze zoekfunctie in de navigatiebalk bovenaan erg krachtig. Als je het antwoord op je vraag niet kunt vinden, aarzel dan niet om contact op te nemen met [ons ondersteuningsteam](https://dodona.be/nl/contact).
 
 
-## API tokens
+## API en API tokens
 - [Wat is een API token?](./api-tokens/#wat-is-een-api-token)
 - [Hoe maak ik een API token aan?](./api-tokens/#hoe-maak-ik-een-api-token-aan)
 - [Hoe kan ik de Dodona API gebruiken?](./api-tokens/#hoe-kan-ik-de-dodona-api-gebruiken)


### PR DESCRIPTION
This PR renames the API tokens FAQ page to API and API tokens. It adds a question about how to use the Dodona API. The information came from #149.

Closes #149
Closes #3