### PR TITLE
Add support for separate sidebar title

### DIFF
--- a/.vitepress/sidebar.ts
+++ b/.vitepress/sidebar.ts
@@ -32,7 +32,7 @@ function getSidebarItems(directory: string, options: Options): SortableSidebarIt
         continue;
       }
       const data = matter.read(indexPage);
-      const title = data.data.title ?? "";
+      const title = data.data.sidebarTitle ?? data.data.title ?? "";
       const order = data.data.order ?? Infinity;
       const otherChildren = sortSidebarItems(getSidebarItems(subitem, options));
 
@@ -64,7 +64,7 @@ function getSidebarItems(directory: string, options: Options): SortableSidebarIt
         continue;
       }
       const data = matter.read(subitem);
-      const title = data.data.title ?? "";
+      const title = data.data.sidebarTitle ?? data.data.title ?? "";
       const order = data.data.order ?? Infinity;
       sidebarItems.push([order, {
         text: title,


### PR DESCRIPTION
Add support to provide a separate title to use in the sidebar. The reason being we often want the sidebar title to be shorter than the page title itself. So, now you can use the frontmatter attribute `sidebarTitle` to specify a shorter title. If the attribute is present, it will be used for the title of the page in the sidebar; otherwise the normal title is used.