### PR TITLE
Updates to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     time: "13:00"
     timezone: Europe/Brussels
   open-pull-requests-limit: 99
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "13:00"
+    timezone: Europe/Brussels
+  open-pull-requests-limit: 99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,14 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "13:00"
     timezone: Europe/Brussels
   open-pull-requests-limit: 99
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "13:00"
     timezone: Europe/Brussels
   open-pull-requests-limit: 99


### PR DESCRIPTION
- Enable Dependabot for our Actions.
- Move Dependabot to a weekly schedule, daily seems a bit much for a static site.