### PR TITLE
Change links and deprecation message

### DIFF
--- a/en/references/judges/index.md
+++ b/en/references/judges/index.md
@@ -20,10 +20,10 @@ Dodona currently supports the following judges:
 
 ## TESTed
 This judge is recommended by the Dodona team.
-TESTed is a whitebox judge that can be used for multiple programming languages.
+TESTed is a judge that can be used for multiple programming languages.
 It uses a simple custom test format, that is independent of the programming language of the exercise.\
 **Programming languages:** Bash, C, C#, Haskell, Java, JavaScript, Kotlin, Python\
-**Get started** [Documentation](/en/references/tested#designing-exercises-for-dodona), [examples](https://github.com/dodona-edu/universal-judge/tree/master/tests/exercises) \
+**Get started** [Documentation](/en/guides/exercises/), [examples](https://github.com/dodona-edu/example-exercises/tree/master/tested) \
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## R
@@ -89,41 +89,64 @@ It does render the Markdown code of a student and can be useful to manually eval
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Python
+::: warning Note
+We do not recommend using this judge for new exercises.
+Use [TESTed](/en/guides/exercises/) for new Python exercises instead.
+:::
+
 Python/Pythia is the first judge that was created for Dodona.
-It is a Python judge that allows simple input/output tests or more advanced doctests.
-This judge has been deprecated and should only be used for legacy exercises.
-If you want to create your own Python exercises, we recommend you to use the [TESTed judge](#tested) instead.\
+It is a Python judge that allows simple input/output tests or more advanced doctests.\
 **Programming languages:** Python\
 **Get started** [Documentation](/en/references/judges/python-judge), [examples](https://github.com/dodona-edu/example-exercises/tree/master/python) \
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Javascript
+
+::: warning Note
+We do not recommend using this judge for new exercises.
+Use [TESTed](/en/guides/exercises/) for new Javascript exercises instead.
+:::
+
 Javascript is a judge that can be used for exercises on the JavaScript programming language.
-It is undocumented and has a lot of very usecase specific implementations.
-If you want to create your own JavaScript exercises, we recommend you to use the [TESTed judge](#tested) instead.\
+It is undocumented and has a lot of very usecase specific implementations.\
 **Programming languages:** JavaScript\
 **Get started** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Bash
+
+::: warning Note
+We do not recommend using this judge for new exercises.
+Use [TESTed](/en/guides/exercises/) for new Bash exercises instead.
+:::
+
+
 Bash is a judge that can be used for exercises on the bash terminal.
-It is undocumented and has a lot of very usecase specific implementations.
-If you want to create your own Bash exercises, we recommend you to use the [TESTed judge](#tested) instead.
+It is undocumented and has a lot of very use-case-specific implementations.\
 **Programming languages:** Bash\
 **Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), contact the creators to get more info about this judge. \
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Csharp (Deprecated)
-The Csharp judge is deprecated and should only be used for legacy exercises.
-If you want to create your own C# exercises, we recommend you to use the [TESTed judge](#tested) instead.\
+
+::: warning Deprecated
+Do not make new exercises for this judge.
+Use [TESTed](/en/guides/exercises/) for new C# exercises instead.
+:::
+
+Csharp is a judge that can be used for exercises in C#.\
 **Programming languages:** C#\
 **Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## JUnit (Deprecated)
-The JUnit judge is a judge for Java 8 exercises.
-It is deprecated and should only be used for legacy exercises.
-If you want to create your own Java exercises, we recommend you to use the [Java judge](#java) instead.\
+
+::: warning Deprecated
+Do not make new exercises for this judge.
+Use the [Java judge](#java) instead.
+:::
+
+The JUnit judge is a judge for Java 8 exercises.\
 **Programming languages:** Java\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-java8), [examples](https://github.com/dodona-edu/example-exercises/tree/master/java) \
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)

--- a/en/references/judges/python-judge/index.md
+++ b/en/references/judges/python-judge/index.md
@@ -5,8 +5,10 @@ order: 5
 ---
 
 ::: warning
-This judge has been deprecated and should only be used for legacy exercises.
-If you want to create your own Python exercises, we recommend you to use the [TESTed judge](/nl/references/judges/#tested) instead.
+We do not recommend this judge for new exercises.
+This judge is no longer actively developed.
+
+Use [TESTed](/en/guides/exercises/) to create new Python exercises instead.
 :::
 
 ::: warning Sorry

--- a/nl/references/judges/index.md
+++ b/nl/references/judges/index.md
@@ -21,10 +21,10 @@ Dodona ondersteunt momenteel de volgende judges:
 
 ## TESTed
 Deze judge wordt aanbevolen door het Dodona-team.
-TESTed is een whitebox judge die voor meerdere programmeertalen gebruikt kan worden.
+TESTed is een judge die voor meerdere programmeertalen gebruikt kan worden.
 Het gebruikt een eenvoudig eigen testformaat, dat onafhankelijk is van de programmeertaal.\
 **Programmeertalen:** Bash, C, C#, Haskell, Java, JavaScript, Kotlin, Python\
-**Aan de slag** [Documentatie](/nl/references/tested#oefeningen-ontwerpen-voor-dodona), [voorbeelden](https://github.com/dodona-edu/universal-judge/tree/master/tests/exercises) \
+**Aan de slag** [Documentatie](/nl/guides/exercises/), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/tested) \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## R
@@ -90,40 +90,64 @@ Het geeft wel de markdown code van een leerling weer en kan handig zijn om de ui
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Python
+
+::: warning Opmerking
+We raden af om nieuwe oefeningen te maken voor deze judge.
+Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) voor nieuwe Python-oefeningen.
+:::
+
 Python/Pythia is de eerste judge die is gemaakt voor Dodona.
-Het is een Python judge die eenvoudige input/output tests of meer geavanceerde doctests mogelijk maakt.
-De judge is verouderd en mag alleen gebruikt worden voor oude oefeningen. We raden aan om de [TESTed judge](#tested) te gebruiken voor nieuwe Python-oefeningen.\
+Het is een Python judge die eenvoudige input/output tests of meer geavanceerde doctests mogelijk maakt.\
 **Programmeertalen:** Python\
 **Aan de slag** [Documentatie](/nl/references/judges/python-judge), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/python) \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Javascript
+
+::: warning Opmerking
+We raden af om nieuwe oefeningen te maken voor deze judge.
+Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) voor nieuwe Javascript-oefeningen.
+:::
+
 JavaScript is een judge die gebruikt kan worden voor oefeningen in de programmeertaal JavaScript.
-Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
-Als je je eigen JavaScriptoefeningen wilt maken, raden we je aan om de [TESTed-judge](#tested) te gebruiken.\
+Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.\
 **Programmeertalen:** Javascript\
 **Aan de slag** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Bash
+
+::: warning Opmerking
+We raden af om nieuwe oefeningen te maken voor deze judge.
+Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) voor nieuwe Bash-oefeningen.
+:::
+
 Bash is een judge die gebruikt kan worden voor oefeningen op de Bash terminal.
-Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
-Als je je eigen Bash-oefeningen wilt maken, raden we aan in plaats daarvan de [TESTed-judge](#tested) te gebruiken.\
+Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.\
 **Programmeertalen:** Bash\
 **Aan de slag** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), neem contact op met de makers voor meer informatie over deze judge. \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Csharp (Deprecated)
-De Csharp-judge is verouderd en mag alleen gebruikt worden voor oude oefeningen.
-Als je je eigen C#-oefeningen wilt maken, raden we aan in plaats daarvan de [TESTed judge](#tested) te gebruiken.\
+
+::: warning Verouderd
+Maak geen nieuwe oefeningen voor deze judge.
+Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) voor nieuwe C#-oefeningen.
+:::
+
+Csharp is een judge die gebruikt kan worden voor oefeningen in C#.\
 **Programmeertalen:** C# \
 **Aan de slag** [Voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## JUnit (Deprecated)
-De JUnit-judge gebruikt het JUnit-framework  voor oefeningen in de programmeertaal Java 8.
-Het is verouderd en mag alleen gebruikt worden voor oude oefeningen.
-Als je je eigen Java-oefeningen wilt maken, raden we je aan om in plaats daarvan de [Java-judge](#java) te gebruiken. \
+
+::: warning Verouderd
+Maak geen nieuwe oefeningen voor deze judge.
+Gebruik in plaats daarvan de [Java-judge](#java).
+:::
+
+De JUnit-judge gebruikt het JUnit-framework voor oefeningen in de programmeertaal Java 8.\
 **Programmeertalen:** Java \
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java8), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/java) \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)

--- a/nl/references/judges/python-judge/index.md
+++ b/nl/references/judges/python-judge/index.md
@@ -4,8 +4,11 @@ description: "Python judge"
 order: 5
 ---
 
-::: warning
-Deze judge is verouderd en wordt niet meer actief ontwikkeld. Gebruik de [TESTed judge](/nl/references/judges/#tested) om nieuwe oefeningen te maken.
+::: warning Opmerking
+We raden af om nieuwe oefeningen te maken voor deze judge.
+Deze judge wordt niet meer actief ontwikkeld.
+
+Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) om nieuwe Python-oefeningen te maken.
 :::
 
 # Python judge


### PR DESCRIPTION
- Links to the guide from the deprecation messages
- Slightly change wording on messages

This also puts the deprecation notices on the judge overview page in warnings, as I thought that it could be clearer that these judges are no longer recommended:

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/1756811/279121610-a3d88faf-adfb-4f80-9fd8-e31008a6547c.png" alt="image" style="max-width: 70%;">
</details>

