### PR TITLE
Add warning that something is advanced

### DIFF
--- a/nl/guides/exercises/testsuites/index.md
+++ b/nl/guides/exercises/testsuites/index.md
@@ -295,6 +295,13 @@ Het is niet verplicht om argumenten te gebruiken:
 
 ## Taalspecifieke expressies en statements
 
+::: warning Geavanceerde materie
+Taalspecifieke expressies en statements heb je voor de meeste oefeningen niet nodig.
+
+Als je toch denkt taalspecifieke expressies en statements nodig te hebben, dan horen we graag waarom: aarzel niet om ons een [e-mail te sturen](mailto:dodona@ugent.be?subject=Taalspecifieke%20expressies) om je gebruik te melden.
+Zo kunnen we TESTed misschien uitbreiden met nieuwe functionaliteit, of jouw specifieke use-case gemakkelijker maken.
+:::
+
 In bepaalde gevallen wil je iets doen waarvoor er in TESTed nog geen ondersteuning is.
 Een voorbeeld is het gebruik van lambda's in Python (of Java), of het gebruik van operatoren.
 
@@ -317,7 +324,7 @@ In onderstaande voorbeeld wordt een functie opgeroepen met als argument de som v
     return: !v "2"
 ```
 
-::: warning
+::: info Merk op
 Bij het gebruik van taalspecifieke expressies en statements ben je zelf verantwoordelijk om de juiste prefix van functies te gebruiken (de `(S|s)ubmission` in het voorbeeld).
 Bovendien zullen expressies niet werken bij functies met returnwaarde `void`.
 


### PR DESCRIPTION
I have seen some exercises that use this while there isn't an apparent reason. By adding this warning, it should be very clear that this is advanced stuff. I also invited users to contact us if they need this, since we are interested in these use cases.