### PR TITLE
Update docs

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -29,3 +29,15 @@
 .medium-zoom-image {
     z-index: 21;
 }
+
+.table-of-contents .VPBadge {
+    display: none;
+}
+
+.table-of-contents a {
+    text-decoration: none;
+}
+
+.table-of-contents a:hover {
+    text-decoration: underline;
+}

--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -41,3 +41,7 @@
 .table-of-contents a:hover {
     text-decoration: underline;
 }
+
+.table-of-contents ul ul {
+    display: none;
+}

--- a/en/faq/activities/index.md
+++ b/en/faq/activities/index.md
@@ -10,3 +10,6 @@ title: Exercises and reading activities
 A draft is an exercise or reading activity that has not been published yet. Draft activities are only visible for repository owners and course admins and are used to create and test activities before they are published. When you add a new exercise to Dodona, it will automatically be in draft mode until you publish it.
 
 On the home page of Dodona, you can find all your drafts. This gives you an overview of all the activities you are still working on. Once the exercise is ready, you can publish it. To do this, navigate to the activity and click "Publish" at the top of the page.
+
+## How do I create new exercises? <Badge type="tip" text="teacher" />
+As a teacher, you can use the hundreds of exercises that are available in Dodona, but you can also create new exercises yourself. You can follow [this guide](/en/guides/exercises/creating-exercises/introduction) for this.

--- a/en/faq/activities/index.md
+++ b/en/faq/activities/index.md
@@ -1,24 +1,12 @@
 ---
-title: Activities
+title: Exercises and reading activities
 ---
 
-# FAQ: Activities
+# FAQ: Exercises and reading activities
 
 [[toc]]
 
-## What is a draft activity?
-Every newly added activity is considered a draft activity until they are published.
+## What is a draft activity? <Badge type="tip" text="teacher" />
+A draft is an exercise or reading activity that has not been published yet. Draft activities are only visible for repository owners and course admins and are used to create and test activities before they are published. When you add a new exercise to Dodona, it will automatically be in draft mode until you publish it.
 
-The idea is that an activity stays in draft mode until its creator greenlights it manually using the Dodona UI.
-
-## What is the effect of a draft activity?
-The concept of draft activities serves several goals.
-
-### Prevent clutter
-Draft activities are only visible for repository owners and course admins for courses with the activity. This prevents that multiple copies of our example exercises are present in the global database for everyone to see.
-
-### Reduce false-positive error messages
-The Dodona admins are notified of severe errors (`internal error`) during the execution of a submission. When a teacher is creating a new exercise and experimenting with adding tests, these errors are quite common. Because of this, the Dodona admins often ignore these messages, causing real issues to be unnoticed. When an exercise is still in draft mode, we will no longer notify the Dodona admins.
-
-### Improve discoverability
-When you add a new exercise to Dodona, it is not always easy to find that exercise and try it yourself. We will now list all draft exercises of a user on the home page, making these easier to find.
+On the home page of Dodona, you can find all your drafts. This gives you an overview of all the activities you are still working on. Once the exercise is ready, you can publish it. To do this, navigate to the activity and click "Publish" at the top of the page.

--- a/en/faq/index.md
+++ b/en/faq/index.md
@@ -18,12 +18,15 @@ In this FAQ section you will find answers to the most frequently asked questions
 - [How do I create an API token?](./api-tokens/#how-do-i-create-an-api-token)
 - [How can I use the Dodona API?](./api-tokens/#how-can-i-use-the-dodona-api)
 
+## Exercises and reading activities
+- [What is a draft activity?](./activities/#what-is-a-draft-activity)
+- [How do I create new exercises?](./activities/#how-do-i-create-new-exercises)
+
 ## Featured courses
 - [What is a featured courses?](./featured-courses/#what-is-a-featured-course)
 - [I made a course, how can I get it featured?](./featured-courses/#i-made-a-course-how-can-i-get-it-featured)
 - [How can I use a featured course?](./featured-courses/#how-can-i-use-a-featured-course)
 - [Which featured courses are available?](./featured-courses/#which-featured-courses-are-available)
-
 
 ## IDE plugins
 - [What is an IDE plugin?](./ide-plugins/#what-is-an-ide-plugin)
@@ -41,7 +44,3 @@ In this FAQ section you will find answers to the most frequently asked questions
 - [How can I comment on a students' submission?](./annotations/#how-can-i-comment-on-a-students-submission)
 - [How can I save and reuse comments?](./annotations/#how-can-i-save-and-reuse-comments)
 - [Why can't I find my saved comments?](./annotations/#why-cant-i-find-my-saved-comments)
-
-## Activities
-- [What is a draft activity?](./activities/#what-is-a-draft-activity)
-- [What is the effect of a draft activity?](./activities/#what-is-the-effect-of-a-draft-activity)

--- a/en/references/index.md
+++ b/en/references/index.md
@@ -12,6 +12,7 @@ Here you can find up-to-date descriptions of the Dodona config files and directo
 * [Repository directory structure](repository-directory-structure)
 * [Exercise directory structure](exercise-directory-structure)
 * [Judges](judges)
+* [TESTed](tested)
 
 ## In Dutch
 * [Python judge](judges/python-judge)

--- a/en/references/judges/index.md
+++ b/en/references/judges/index.md
@@ -6,62 +6,15 @@ order: 6
 
 # Judges
 
-This guide is written for teachers who are creating exercises for Dodona.
+On this page you can find an overview of all judges that are available on Dodona. A judge is a piece of software that is responsible for testing the solutions of students and writing the results in a format that Dodona understands.
 
-Before you create an exercise, you should decide which _judge_ you want to use.
-A judge is the program that will evaluate the submissions of students.
-It is often written for one specific programming language, but supporting a set of programming languages is also possible.
-Each judge has its own configuration options, we will provide a link to the relevant documentation for each judge below.
-These judge-specific options should be provided in the `evaluation` directory of the [exercise configuration](/en/references/exercise-directory-structure).
-
-Advanced users can also create their own judge, see [this guide](/en/references/judges/creating-a-judge).
-
-Dodona currently supports the following judges:
-
-## TESTed
-This judge is recommended by the Dodona team.
-TESTed is a judge that can be used for multiple programming languages.
-It uses a simple custom test format, that is independent of the programming language of the exercise.\
-**Programming languages:** Bash, C, C#, Haskell, Java, JavaScript, Kotlin, Python\
-**Get started** [Documentation](/en/guides/exercises/), [examples](https://github.com/dodona-edu/example-exercises/tree/master/tested) \
-**Created by:** [Team Dodona](mailto:dodona@ugent.be)
-
-## R
-R is a judge that can be used for exercises on the R programming language.\
-**Programming languages:** R\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-r), [examples](https://github.com/dodona-edu/example-exercises/tree/master/R) \
-**Created by:** [Team Dodona](mailto:dodona@ugent.be)
-
-## Java
-The java judge uses the JUnit4 framework to run tests on Java exercises.\
-**Programming languages:** Java\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-java), [examples](https://github.com/dodona-edu/judge-java/tree/master/examples) \
-**Created by:** [Team Dodona](mailto:dodona@ugent.be)
+Most judges only support one programming language, but there are also judges like [TESTed](#TESTed) that support multiple programming languages.
 
 ## C
 C is a judge that uses the GTester framework to run tests on C exercises.\
 **Programming languages:** C\
 **Get started** [Documentation](https://github.com/mvdcamme/C-Judge), [examples](https://github.com/mvdcamme/C-Judge/tree/master/example_exercises) \
 **Created by:** [Maarten Vandercammen](mailto:mvdcamme@vub.ac.be)
-
-## SQL
-The SQL judge supports both query evaluation (DML) and structural database building (DDL).\
-**Programming languages:** SQL\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-sql), [examples](https://github.com/dodona-edu/example-exercises/tree/master/sql) \
-**Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
-
-## Scheme
-Scheme is a judge that supports the `R5RS` variant of the scheme programming language. It uses a custom testframework [dunit](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/collects/dunit) to define the tests.\
-**Programming languages:** Scheme\
-**Get started** [Documentation](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge), [examples](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/example-exercises) \
-**Created by:** [Mathijs Saey](mailto:scpi@dinf.vub.ac.be)
-
-## Prolog
-Prolog is a judge that can be used for exercises on the Prolog programming language.
-It supports PLUnit, QuickCheck and simple input output tests.\
-**Programming languages:** Prolog\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-prolog), [examples](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
-**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Haskell
 Haskell is a judge that uses HUnit to test Haskell exercises. \
@@ -75,11 +28,11 @@ The HTML judge evaluates both the HTML and CSS code of a student, based on a mod
 **Get started** [Documentation](https://github.com/dodona-edu/judge-html), [examples](https://github.com/dodona-edu/example-exercises/tree/master/html) \
 **Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
-## Turtle
-The Turtle judge evaluates the output of a Python Turtle program. It calculates the similarity between the output of the student and the model solution.\
-**Programming languages:** Python (Turtle)\
-**Get started** [Documentation](https://github.com/dodona-edu/judge-turtle) \
-**Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+## Java
+The java judge uses the JUnit4 framework to run tests on Java exercises.\
+**Programming languages:** Java\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-java), [examples](https://github.com/dodona-edu/judge-java/tree/master/examples) \
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Markdown
 The markdown judge is not a real judge as it does not evaluate code.
@@ -88,19 +41,73 @@ It does render the Markdown code of a student and can be useful to manually eval
 **Get started** [Documentation](https://github.com/dodona-edu/judge-markdown) \
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
-## Python
-::: warning Note
-We do not recommend using this judge for new exercises.
-Use [TESTed](/en/guides/exercises/) for new Python exercises instead.
-:::
-
-Python/Pythia is the first judge that was created for Dodona.
-It is a Python judge that allows simple input/output tests or more advanced doctests.\
-**Programming languages:** Python\
-**Get started** [Documentation](/en/references/judges/python-judge), [examples](https://github.com/dodona-edu/example-exercises/tree/master/python) \
+## Prolog
+Prolog is a judge that can be used for exercises on the Prolog programming language.
+It supports PLUnit, QuickCheck and simple input output tests.\
+**Programming languages:** Prolog\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-prolog), [examples](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
-## Javascript
+## R
+R is a judge that can be used for exercises on the R programming language.\
+**Programming languages:** R\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-r), [examples](https://github.com/dodona-edu/example-exercises/tree/master/R) \
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
+
+## Scheme
+Scheme is a judge that supports the `R5RS` variant of the scheme programming language. It uses a custom testframework [dunit](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/collects/dunit) to define the tests.\
+**Programming languages:** Scheme\
+**Get started** [Documentation](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge), [examples](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/example-exercises) \
+**Created by:** [Mathijs Saey](mailto:scpi@dinf.vub.ac.be)
+
+## SQL
+The SQL judge supports both query evaluation (DML) and structural database building (DDL).\
+**Programming languages:** SQL\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-sql), [examples](https://github.com/dodona-edu/example-exercises/tree/master/sql) \
+**Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+
+## TESTed
+This judge is recommended by the Dodona team.
+TESTed is a judge that can be used for multiple programming languages.
+It uses a simple custom test format, that is independent of the programming language of the exercise.\
+**Programming languages:** Bash, C, C#, Haskell, Java, JavaScript, Kotlin, Python\
+**Get started** [Documentation](/en/guides/exercises/), [examples](https://github.com/dodona-edu/example-exercises/tree/master/tested) \
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
+
+## Turtle
+The Turtle judge evaluates the output of a Python Turtle program. It calculates the similarity between the output of the student and the model solution.\
+**Programming languages:** Python (Turtle)\
+**Get started** [Documentation](https://github.com/dodona-edu/judge-turtle) \
+**Created by:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+
+## Deprecated judges
+
+### Bash
+
+::: warning Note
+We do not recommend using this judge for new exercises.
+Use [TESTed](/en/guides/exercises/) for new Bash exercises instead.
+:::
+
+Bash is a judge that can be used for exercises on the bash terminal.
+It is undocumented and has a lot of very use-case-specific implementations.\
+**Programming languages:** Bash\
+**Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), contact the creators to get more info about this judge. \
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
+
+### Csharp
+
+::: warning Note
+We do not recommend using this judge for new exercises.
+Use [TESTed](/en/guides/exercises/) for new C# exercises instead.
+:::
+
+Csharp is a judge that can be used for exercises in C#.\
+**Programming languages:** C#\
+**Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)
+
+### Javascript
 
 ::: warning Note
 We do not recommend using this judge for new exercises.
@@ -113,36 +120,10 @@ It is undocumented and has a lot of very usecase specific implementations.\
 **Get started** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
-## Bash
+### JUnit
 
 ::: warning Note
 We do not recommend using this judge for new exercises.
-Use [TESTed](/en/guides/exercises/) for new Bash exercises instead.
-:::
-
-
-Bash is a judge that can be used for exercises on the bash terminal.
-It is undocumented and has a lot of very use-case-specific implementations.\
-**Programming languages:** Bash\
-**Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), contact the creators to get more info about this judge. \
-**Created by:** [Team Dodona](mailto:dodona@ugent.be)
-
-## Csharp (Deprecated)
-
-::: warning Deprecated
-Do not make new exercises for this judge.
-Use [TESTed](/en/guides/exercises/) for new C# exercises instead.
-:::
-
-Csharp is a judge that can be used for exercises in C#.\
-**Programming languages:** C#\
-**Get started** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
-**Created by:** [Team Dodona](mailto:dodona@ugent.be)
-
-## JUnit (Deprecated)
-
-::: warning Deprecated
-Do not make new exercises for this judge.
 Use the [Java judge](#java) instead.
 :::
 
@@ -151,8 +132,14 @@ The JUnit judge is a judge for Java 8 exercises.\
 **Get started** [Documentation](https://github.com/dodona-edu/judge-java8), [examples](https://github.com/dodona-edu/example-exercises/tree/master/java) \
 **Created by:** [Team Dodona](mailto:dodona@ugent.be)
 
+### Python
+::: warning Note
+We do not recommend using this judge for new exercises.
+Use [TESTed](/en/guides/exercises/) for new Python exercises instead.
+:::
 
-
-
-
-
+Python/Pythia is the first judge that was created for Dodona.
+It is a Python judge that allows simple input/output tests or more advanced doctests.\
+**Programming languages:** Python\
+**Get started** [Documentation](/en/references/judges/python-judge), [examples](https://github.com/dodona-edu/example-exercises/tree/master/python) \
+**Created by:** [Team Dodona](mailto:dodona@ugent.be)

--- a/en/references/judges/index.md
+++ b/en/references/judges/index.md
@@ -10,6 +10,10 @@ On this page you can find an overview of all judges that are available on Dodona
 
 Most judges only support one programming language, but there are also judges like [TESTed](#TESTed) that support multiple programming languages.
 
+::: tip Recommended judge
+If you're trying to decide which judge to use for your exercises, we strongly recommend taking a look at [TESTed](#tested) first.
+:::
+
 ## C
 C is a judge that uses the GTester framework to run tests on C exercises.\
 **Programming languages:** C\

--- a/en/references/judges/python-judge/index.md
+++ b/en/references/judges/python-judge/index.md
@@ -3,6 +3,11 @@ title: "[nl] Python judge"
 description: "Python judge"
 order: 5
 ---
+::: warning Sorry
+For now, this page is only available in Dutch. Sorry!
+:::
+
+# Python judge
 
 ::: warning
 We do not recommend this judge for new exercises.
@@ -11,11 +16,6 @@ This judge is no longer actively developed.
 Use [TESTed](/en/guides/exercises/) to create new Python exercises instead.
 :::
 
-::: warning Sorry
-For now, this page is only available in Dutch. Sorry!
-:::
-
-# Python judge
 
 Alle Python judges zijn in Python geschreven en delen een gemeenschappelijke basisklasse `Judge`. De basisklasse voor master judges heet `MasterJudge`. De basisklasse voor interactieve judges heet `TestcaseJudge`. Twee generieke interactieve judges zijn al geïmplementeerd:
 

--- a/en/references/tested/index.md
+++ b/en/references/tested/index.md
@@ -5,6 +5,10 @@ description: "TESTed judge"
 
 # TESTed: one judge to rule them all
 
+::: tip
+This is the extended documentation for the TESTed judge. A guide aimed at teachers who are creating an exercise for the first time is available in [this guide](/en/guides/exercises/).
+:::
+
 TESTed is an *educational software testing framework* (also known as a *judge*)
 to test submissions for programming exercises using a programming-language-independent test suite.
 It allows specifying software requirements (i.e. the tests) for an exercise once,

--- a/nl/faq/activities/index.md
+++ b/nl/faq/activities/index.md
@@ -1,24 +1,12 @@
 ---
-title: Activiteiten
+title: Oefeningen en leesactiviteiten
 ---
 
-# FAQ: Activiteiten
+# FAQ: Oefeningen en leesactiviteiten
 
 [[toc]]
 
-## Wat is een conceptactiviteit?
-Elke nieuw toegevoegde activiteit wordt beschouwd als een conceptactiviteit totdat deze wordt gepubliceerd.
+## Wat is een concept? <Badge type="tip" text="lesgever" />
+Een concept is een oefening of leesactiviteit die nog niet is gepubliceerd. Concepten zijn alleen zichtbaar voor de eigenaars van de repository en cursusbeheerders en worden gebruikt om oefeningen te maken en te testen voordat ze worden gepubliceerd. Als je een nieuwe oefening aan Dodona toevoegt, dan zal die automatisch in conceptmodus staan tot je ze publiceert.
 
-Het idee is dat een activiteit in conceptmodus blijft totdat de maker deze handmatig goedkeurt met behulp van Dodona.
-
-## Wat is het doel van concept activiteiten?
-Concept activiteiten dienen verschillende doelen.
-
-### Verwarring vermijden
-Concept activiteiten zijn alleen zichtbaar voor repository-eigenaren en cursusbeheerders voor cursussen met de activiteit. Dit voorkomt dat er meerdere kopieën van onze voorbeeldoefeningen in de centrale database aanwezig zijn.
-
-### Minder valspositieve foutmeldingen
-De Dodona-beheerders worden op de hoogte gebracht van interne fouten tijdens de uitvoering van een oplossing. Wanneer een lesgever een nieuwe oefening maakt en experimenteert met het toevoegen van tests, komen deze fouten vaak voor. Hierdoor negeren de Dodona-beheerders deze berichten vaak, waardoor echte problemen onopgemerkt blijven. Wanneer een oefening nog in conceptmodus is, krijgen de Dodona-beheerders geen melding van interne fouten.
-
-### Verbeterde vindbaarheid
-Wanneer je een nieuwe oefening aan Dodona toevoegt, is het niet altijd gemakkelijk om die oefening te vinden en zelf te proberen. Alle jouw conceptoefeningen staan op de startpagina vermeld, waardoor deze gemakkelijker te vinden zijn.
+Op de startpagina van Dodona kan je al jouw concepten terugvinden. Zo krijg je een overzicht van alle oefeningen die je nog aan het opstellen bent. Eenmaal de oefening klaar is, kan je ze publiceren. Navigeer hiervoor naar de oefening en klik bovenaan de pagina "Publiceren".

--- a/nl/faq/activities/index.md
+++ b/nl/faq/activities/index.md
@@ -10,3 +10,6 @@ title: Oefeningen en leesactiviteiten
 Een concept is een oefening of leesactiviteit die nog niet is gepubliceerd. Concepten zijn alleen zichtbaar voor de eigenaars van de repository en cursusbeheerders en worden gebruikt om oefeningen te maken en te testen voordat ze worden gepubliceerd. Als je een nieuwe oefening aan Dodona toevoegt, dan zal die automatisch in conceptmodus staan tot je ze publiceert.
 
 Op de startpagina van Dodona kan je al jouw concepten terugvinden. Zo krijg je een overzicht van alle oefeningen die je nog aan het opstellen bent. Eenmaal de oefening klaar is, kan je ze publiceren. Navigeer hiervoor naar de oefening en klik bovenaan de pagina "Publiceren".
+
+## Hoe maak ik nieuwe oefeningen aan? <Badge type="tip" text="lesgever" />
+Als lesgever kan je gebruikmaken van de honderden oefeningen die in Dodona aanwezig zijn, maar je kan ook zelf nieuwe oefeningen aanmaken. Je kan hiervoor [dit stappenplan](/nl/guides/exercises/creating-exercises/introduction) volgen.

--- a/nl/faq/index.md
+++ b/nl/faq/index.md
@@ -25,6 +25,10 @@ In deze FAQ-sectie vind je antwoorden op de meest gestelde vragen over het gebru
 - [Hoe installeer ik de VS Code-extensie?](./ide-plugins/#hoe-installeer-ik-de-vs-code-extensie)
 - [Hoe kan ik de VS Code-extensie gebruiken?](./ide-plugins/#hoe-kan-ik-de-vs-code-extensie-gebruiken)
 
+## Oefeningen en leesactiviteiten
+- [Wat is een concept?](./activities/#wat-is-een-conceptactiviteit)
+- [Hoe maak ik nieuwe oefeningen aan?](./activities/#hoe-maak-ik-nieuwe-oefeningen-aan)
+
 ## Uitgelichte cursussen
 - [Wat is een uitgelichte cursus?](./featured-courses/#wat-is-een-uitgelichte-cursus)
 - [Ik heb een cursus gemaakt, hoe kan ik deze laten uitlichten?](./featured-courses/#ik-heb-een-cursus-gemaakt-hoe-kan-ik-deze-laten-uitlichten)
@@ -40,7 +44,3 @@ In deze FAQ-sectie vind je antwoorden op de meest gestelde vragen over het gebru
 - [Hoe kan ik opmerkingen geven op een oplossing van een student?](./annotations/#hoe-kan-ik-opmerkingen-geven-op-een-oplossing-van-een-student)
 - [Hoe kan ik opmerkingen opslaan en hergebruiken?](./annotations/#hoe-kan-ik-opmerkingen-opslaan-en-hergebruiken)
 - [Waarom vind ik mijn opgeslagen opmerkingen niet terug?](./annotations/#waarom-vind-ik-mijn-opgeslagen-opmerkingen-niet-terug)
-
-## Activiteiten
-- [Wat is een conceptactiviteit?](./activities/#wat-is-een-conceptactiviteit)
-- [Wat is het doel van conceptactiviteiten?](./activities/#wat-is-het-doel-van-concept-activiteiten)

--- a/nl/references/index.md
+++ b/nl/references/index.md
@@ -12,3 +12,4 @@ Hier vind je up-to-date beschrijvingen van de Dodona configuratiebestanden en ma
 * [Oefeningmap-structuur](exercise-directory-structure)
 * [Python judge](judges/python-judge)
 * [Judges](judges)
+* [TESTed](tested)

--- a/nl/references/judges/index.md
+++ b/nl/references/judges/index.md
@@ -6,63 +6,15 @@ order: 6
 
 # Judges
 
-Deze gids is geschreven voor docenten die oefeningen maken voor Dodona.
+Op deze pagina vind je een overzicht van alle judges die beschikbaar zijn op Dodona. Een judge is een stukje software dat verantwoordelijk is om de oplossingen van studenten te testen en de resultaten hiervan weg te schrijven in een formaat dat Dodona begrijpt.
 
-Voordat je een oefening maakt, moet je beslissen welke _judge_ je wilt gebruiken.
-De judge is het programma dat de inzendingen van leerlingen beoordeelt.
-Het is vaak geschreven voor één specifieke programmeertaal, of voor een reeks programmeertalen.
-Elke judge heeft zijn eigen configuratie-opties.
-We geven hieronder een link naar de relevante documentatie voor elke judge.
-Deze judge specifieke opties moeten worden voorzien in de map `evaluation` van de [oefening-specifieke configuratie](/nl/references/exercise-directory-structure).
-
-Gevorderde gebruikers kunnen ook hun eigen judge aanmaken, zie [deze gids](/nl/references/judges/creating-a-judge).
-
-Dodona ondersteunt momenteel de volgende judges:
-
-## TESTed
-Deze judge wordt aanbevolen door het Dodona-team.
-TESTed is een judge die voor meerdere programmeertalen gebruikt kan worden.
-Het gebruikt een eenvoudig eigen testformaat, dat onafhankelijk is van de programmeertaal.\
-**Programmeertalen:** Bash, C, C#, Haskell, Java, JavaScript, Kotlin, Python\
-**Aan de slag** [Documentatie](/nl/guides/exercises/), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/tested) \
-**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
-
-## R
-R is een judge die gebruikt kan worden voor oefeningen in de programmeertaal R.\
-**Programmeertalen:** R\
-**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-r), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/R) \
-**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
-
-## Java
-Java is judge die het JUnit4-framework gebruikt om tests op Java-oefeningen uit te voeren.\
-**Programmeertalen:** Java\
-**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java), [voorbeelden](https://github.com/dodona-edu/judge-java/tree/master/examples) \
-**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
+De meeste judges ondersteunen maar één programmeertaal, maar er zijn ook judges zoals [TESTed](#TESTed) die meerdere programmeertalen ondersteunen.
 
 ## C
 C is een judge die het GTester-framework gebruikt om testen uit te voeren op C-oefeningen.\
 **Programmeertalen:** C\
 **Aan de slag** [Documentatie](https://github.com/mvdcamme/C-Judge), [voorbeelden](https://github.com/mvdcamme/C-Judge/tree/master/example_exercises) \
 **Gemaakt door:** [Maarten Vandercammen](mailto:mvdcamme@vub.ac.be)
-
-## SQL
-De SQL judge ondersteunt zowel query evaluatie (DML) als structurele database opbouw (DDL).\
-**Programmeertalen:** SQL\
-**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-sql), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/sql) \
-**Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
-
-## Scheme
-Scheme is een judge die de `R5RS`-variant van de programmeertaal Scheme ondersteunt. Het gebruikt een aangepast testframework [dunit](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/collects/dunit) om de tests te definiëren.\
-**Programmeertalen:** Scheme \
-**Aan de slag** [Documentatie](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge), [voorbeelden](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/example-exercises) \
-**Gemaakt door:** [Mathijs Saey](mailto:scpi@dinf.vub.ac.be)
-
-## Prolog
-Prolog is een judge die gebruikt kan worden voor oefeningen in de programmeertaal Prolog.
-Het ondersteunt PLUnit, QuickCheck en eenvoudige input-outputtests.\
-**Programmeertalen:** Prolog\
-**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-prolog), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
-**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Haskell
 Haskell is een judge die HUnit gebruikt om Haskell-oefeningen te testen. \
@@ -76,11 +28,11 @@ De HTML judge beoordeelt zowel de HTML- als de CSS-code van een student, op basi
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-html), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/html) \
 **Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
 
-## Turtle
-De Turtle-judge evalueert de uitvoer van een Python Turtle programma. Het berekent de overeenkomst tussen de uitvoer van de leerling en de modeloplossing. \
-**Programmeertalen:** Python (Turtle)**
-**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-turtle) \
-**Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+## Java
+Java is judge die het JUnit4-framework gebruikt om tests op Java-oefeningen uit te voeren.\
+**Programmeertalen:** Java\
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java), [voorbeelden](https://github.com/dodona-edu/judge-java/tree/master/examples) \
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
 ## Markdown
 De Markdown-judge is geen echte judge omdat hij geen code evalueert.
@@ -89,35 +41,53 @@ Het geeft wel de markdown code van een leerling weer en kan handig zijn om de ui
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-markdown) \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
-## Python
-
-::: warning Opmerking
-We raden af om nieuwe oefeningen te maken voor deze judge.
-Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) voor nieuwe Python-oefeningen.
-:::
-
-Python/Pythia is de eerste judge die is gemaakt voor Dodona.
-Het is een Python judge die eenvoudige input/output tests of meer geavanceerde doctests mogelijk maakt.\
-**Programmeertalen:** Python\
-**Aan de slag** [Documentatie](/nl/references/judges/python-judge), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/python) \
+## Prolog
+Prolog is een judge die gebruikt kan worden voor oefeningen in de programmeertaal Prolog.
+Het ondersteunt PLUnit, QuickCheck en eenvoudige input-outputtests.\
+**Programmeertalen:** Prolog\
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-prolog), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/prolog) \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
-## Javascript
-
-::: warning Opmerking
-We raden af om nieuwe oefeningen te maken voor deze judge.
-Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) voor nieuwe Javascript-oefeningen.
-:::
-
-JavaScript is een judge die gebruikt kan worden voor oefeningen in de programmeertaal JavaScript.
-Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.\
-**Programmeertalen:** Javascript\
-**Aan de slag** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
+## R
+R is een judge die gebruikt kan worden voor oefeningen in de programmeertaal R.\
+**Programmeertalen:** R\
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-r), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/R) \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
-## Bash
+## Scheme
+Scheme is een judge die de `R5RS`-variant van de programmeertaal Scheme ondersteunt. Het gebruikt een aangepast testframework [dunit](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/collects/dunit) om de tests te definiëren.\
+**Programmeertalen:** Scheme \
+**Aan de slag** [Documentatie](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge), [voorbeelden](https://gitlab.soft.vub.ac.be/Structuur1/dodona-judge/-/tree/master/example-exercises) \
+**Gemaakt door:** [Mathijs Saey](mailto:scpi@dinf.vub.ac.be)
 
-::: warning Opmerking
+## SQL
+De SQL judge ondersteunt zowel query evaluatie (DML) als structurele database opbouw (DDL).\
+**Programmeertalen:** SQL\
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-sql), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/sql) \
+**Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+
+## TESTed
+Deze judge wordt aanbevolen door het Dodona-team.
+TESTed is een judge die voor meerdere programmeertalen gebruikt kan worden.
+Het gebruikt een eenvoudig eigen testformaat, dat onafhankelijk is van de programmeertaal.\
+**Programmeertalen:** Bash, C, C#, Haskell, Java, JavaScript, Kotlin, Python\
+**Aan de slag** [Documentatie](/nl/guides/exercises/), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/tested) \
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
+
+## Turtle
+De Turtle-judge evalueert de uitvoer van een Python Turtle programma. Het berekent de overeenkomst tussen de uitvoer van de leerling en de modeloplossing. \
+**Programmeertalen:** Python (Turtle)**
+**Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-turtle) \
+**Gemaakt door:** [Brecht Willems](mailto:Brecht.Willems@UGent.be)
+
+
+## Oude judges
+
+Onderstaande judges zijn verouderd en worden niet meer actief ontwikkeld. Ze blijven beschikbaar voor bestaande oefeningen, maar we raden aan om ze niet meer te gebruiken om nieuwe oefeningen op te stellen.
+
+### Bash
+
+::: warning Opgepast
 We raden af om nieuwe oefeningen te maken voor deze judge.
 Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) voor nieuwe Bash-oefeningen.
 :::
@@ -128,10 +98,10 @@ Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.
 **Aan de slag** [Examples](https://github.com/dodona-edu/example-exercises/tree/master/bash), neem contact op met de makers voor meer informatie over deze judge. \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
-## Csharp (Deprecated)
+### Csharp
 
-::: warning Verouderd
-Maak geen nieuwe oefeningen voor deze judge.
+::: warning Opgepast
+We raden af om nieuwe oefeningen te maken voor deze judge.
 Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) voor nieuwe C#-oefeningen.
 :::
 
@@ -140,14 +110,40 @@ Csharp is een judge die gebruikt kan worden voor oefeningen in C#.\
 **Aan de slag** [Voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/c%23) \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
 
-## JUnit (Deprecated)
+### Javascript
 
-::: warning Verouderd
-Maak geen nieuwe oefeningen voor deze judge.
+::: warning Opgepast
+We raden af om nieuwe oefeningen te maken voor deze judge.
+Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) voor nieuwe Javascript-oefeningen.
+:::
+
+JavaScript is een judge die gebruikt kan worden voor oefeningen in de programmeertaal JavaScript.
+Het is niet gedocumenteerd en heeft veel zeer usecase-specifieke implementaties.\
+**Programmeertalen:** Javascript\
+**Aan de slag** [Github repo](https://github.com/dodona-edu/judge-javascript), [examples](https://github.com/dodona-edu/example-exercises/tree/master/javascript) \
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
+
+### JUnit
+
+::: warning Opgepast
+We raden af om nieuwe oefeningen te maken voor deze judge.
 Gebruik in plaats daarvan de [Java-judge](#java).
 :::
 
 De JUnit-judge gebruikt het JUnit-framework voor oefeningen in de programmeertaal Java 8.\
 **Programmeertalen:** Java \
 **Aan de slag** [Documentatie](https://github.com/dodona-edu/judge-java8), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/java) \
+**Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)
+
+### Python
+
+::: warning Opgepast
+We raden af om nieuwe oefeningen te maken voor deze judge.
+Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) voor nieuwe Python-oefeningen.
+:::
+
+Python/Pythia is de eerste judge die is gemaakt voor Dodona.
+Het is een Python judge die eenvoudige input/output tests of meer geavanceerde doctests mogelijk maakt.\
+**Programmeertalen:** Python\
+**Aan de slag** [Documentatie](/nl/references/judges/python-judge), [voorbeelden](https://github.com/dodona-edu/example-exercises/tree/master/python) \
 **Gemaakt door:** [Team Dodona](mailto:dodona@ugent.be)

--- a/nl/references/judges/index.md
+++ b/nl/references/judges/index.md
@@ -10,6 +10,10 @@ Op deze pagina vind je een overzicht van alle judges die beschikbaar zijn op Dod
 
 De meeste judges ondersteunen maar één programmeertaal, maar er zijn ook judges zoals [TESTed](#TESTed) die meerdere programmeertalen ondersteunen.
 
+::: tip Aanbevolen judge
+Als je twijfelt over welke judge je best gebruikt voor je oefeningen, dan raden we sterk aan om eerst de [TESTed](#tested) judge te bekijken.
+:::
+
 ## C
 C is een judge die het GTester-framework gebruikt om testen uit te voeren op C-oefeningen.\
 **Programmeertalen:** C\

--- a/nl/references/judges/python-judge/index.md
+++ b/nl/references/judges/python-judge/index.md
@@ -4,14 +4,14 @@ description: "Python judge"
 order: 5
 ---
 
+# Python judge
+
 ::: warning Opmerking
 We raden af om nieuwe oefeningen te maken voor deze judge.
 Deze judge wordt niet meer actief ontwikkeld.
 
 Gebruik in plaats daarvan [TESTed](/nl/guides/exercises/) om nieuwe Python-oefeningen te maken.
 :::
-
-# Python judge
 
 Alle Python judges zijn in Python geschreven en delen een gemeenschappelijke basisklasse `Judge`. De basisklasse voor master judges heet `MasterJudge`. De basisklasse voor interactieve judges heet `TestcaseJudge`. Twee generieke interactieve judges zijn al geïmplementeerd:
 

--- a/nl/references/tested/index.md
+++ b/nl/references/tested/index.md
@@ -5,6 +5,10 @@ description: "De TESTed-judge"
 
 # TESTed: one judge to rule them all
 
+::: tip
+Dit is de uitgebreide documentatie voor de TESTed-judge. Een handleiding die gericht is op leerkrachten die voor het eerst een oefening opstellen is beschikbaar in [deze handleiding](/nl/guides/exercises/).
+:::
+
 TESTed is een *educational software testing framework* (ook bekend als een *judge*) dat toelaat om oplossingen voor programmeeroefeningen te beoordelen op basis van een programmeertaalonafhankelijk testplan.
 Het laat om de softwarevereisten (d.w.z. de testen) voor een oefening één keer op te stellen, terwijl oplossingen in verschillende programmeertalen beoordeeld kunnen worden.
 TESTed kan als afzonderlijk tool gebruikt worden, maar is ook geïntegreerd in de elektronische leeromgeving [Dodona](https://dodona.be).


### PR DESCRIPTION
This PR changes a bunch of minor things on the documentation website:
- add missing links
- add a few additional callouts
- tweak the TOC UI
- the list of judges was unsorted and used 2 types of deprecation messages