### PR TITLE
Add explicit judge to config examples

### DIFF
--- a/nl/guides/exercises/examples/_common.md
+++ b/nl/guides/exercises/examples/_common.md
@@ -36,14 +36,20 @@ Maak het bestand `config.json` in de map `minimum` met de volgende inhoud:
       "nl": "Minimum"
     }
   },
+  "evaluation": {
+    "handler": "tested",
+    "test_suite": "suite.yaml"
+  },
   "programming_language": "python",
   "access": "private"
 }
 ```
 
-In dit bestand worden drie dingen gespecifieerd:
+In dit bestand worden een aantal dingen gespecifieerd:
 
-- `names`: De **namen** van de oefening zoals getoond door Dodona in het Nederlands (_nl_) en in het Engels (_en_) (in dit geval zijn beide namen hetzelfde).
+- `description.names`: De **namen** van de oefening zoals getoond door Dodona in het Nederlands (_nl_) en in het Engels (_en_). In dit geval zijn de namen gelijk.
+- `evaluation.handler`: We gebruiken TESTed als judge.
+- `evaluation.test_suite`: Het testplan krijgt de naam `suite.yaml`.
 - `programming_language`: De **programmeertaal** van de oefening: hier kies je in welke programmeertaal je de oplossingen wilt. In dit geval is dat Python.
 - `access`: Het **toegangsniveau** is hier _private_. We kiezen voor een private oefening omdat dit maar een handleiding is, maar we moedigen aan om je oefeningen publiek (_public_) te zetten: dan kunnen andere leerkrachten er ook gebruik van maken (net zoals jij de keuze hebt uit duizenden publieke oefeningen op Dodona).
 

--- a/nl/guides/exercises/examples/class/index.md
+++ b/nl/guides/exercises/examples/class/index.md
@@ -51,14 +51,20 @@ Maak het bestand `config.json` in de map `counter` met de volgende inhoud:
       "nl": "Teller"
     }
   },
+  "evaluation": {
+    "handler": "tested",
+    "test_suite": "suite.yaml"
+  },
   "programming_language": "python",
   "access": "private"
 }
 ```
 
-In dit bestand worden drie dingen gespecifieerd:
+In dit bestand worden een aantal dingen gespecifieerd:
 
-- `names`: De **namen** van de oefening zoals getoond door Dodona in het Nederlands (_nl_) en in het Engels (_en_).
+- `description.names`: De **namen** van de oefening zoals getoond door Dodona in het Nederlands (_nl_) en in het Engels (_en_).
+- `evaluation.handler`: We gebruiken TESTed als judge.
+- `evaluation.test_suite`: Het testplan krijgt de naam `suite.yaml`.
 - `programming_language`: De **programmeertaal** van de oefening: hier kies je in welke programmeertaal je de oplossingen wilt. In dit geval is dat Python.
 - `acces`: Het **toegangsniveau** is hier _private_. We kiezen voor een private oefening omdat dit maar een handleiding is, maar we moedigen aan om je oefeningen publiek (_public_) te zetten: dan kunnen andere leerkrachten er ook gebruik van maken (net zoals jij de keuze hebt uit duizenden publieke oefeningen op Dodona).
 

--- a/nl/guides/exercises/examples/command-line/index.md
+++ b/nl/guides/exercises/examples/command-line/index.md
@@ -52,14 +52,20 @@ Maak het bestand `config.json` in de map `sum` met de volgende inhoud:
       "nl": "Som van getallen"
     }
   },
+  "evaluation": {
+    "handler": "tested",
+    "test_suite": "suite.yaml"
+  },
   "programming_language": "python",
   "access": "private"
 }
 ```
 
-In dit bestand worden drie dingen gespecifieerd:
+In dit bestand worden een aantal dingen gespecifieerd:
 
-- `names`: De **namen** van de oefening zoals getoond door Dodona in het Nederlands (_nl_) en in het Engels (_en_).
+- `description.names`: De **namen** van de oefening zoals getoond door Dodona in het Nederlands (_nl_) en in het Engels (_en_).
+- `evaluation.handler`: We gebruiken TESTed als judge.
+- `evaluation.test_suite`: Het testplan krijgt de naam `suite.yaml`.
 - `programming_language`: De **programmeertaal** van de oefening: hier kies je in welke programmeertaal je de oplossingen wilt. In dit geval is dat Python.
 - `access`: Het **toegangsniveau** is hier _private_. We kiezen voor een private oefening omdat dit maar een handleiding is, maar we moedigen aan om je oefeningen publiek (_public_) te zetten: dan kunnen andere leerkrachten er ook gebruik van maken (net zoals jij de keuze hebt uit duizenden publieke oefeningen op Dodona).
 

--- a/nl/guides/exercises/examples/input-output/index.md
+++ b/nl/guides/exercises/examples/input-output/index.md
@@ -52,14 +52,20 @@ Maak het bestand `config.json` in de map `hello-world` met de volgende inhoud:
       "nl": "Hello World"
     }
   },
+  "evaluation": {
+    "handler": "tested",
+    "test_suite": "suite.yaml"
+  },
   "programming_language": "python",
   "access": "private"
 }
 ```
 
-In dit bestand worden drie dingen gespecifieerd:
+In dit bestand worden een aantal dingen gespecifieerd:
 
-- `names`: De **namen** van de oefening zoals getoond door Dodona in het Nederlands (_nl_) en in het Engels (_en_) (in dit geval zijn beide namen hetzelfde).
+- `description.names`: De **namen** van de oefening zoals getoond door Dodona in het Nederlands (_nl_) en in het Engels (_en_). In dit geval zijn de namen gelijk.
+- `evaluation.handler`: We gebruiken TESTed als judge.
+- `evaluation.test_suite`: Het testplan krijgt de naam `suite.yaml`.
 - `programming_language`: De **programmeertaal** van de oefening: hier kies je in welke programmeertaal je de oplossingen wilt. In dit geval is dat Python.
 - `access`: Het **toegangsniveau** is hier _private_. We kiezen voor een private oefening omdat dit maar een handleiding is, maar we moedigen aan om je oefeningen publiek (_public_) te zetten: dan kunnen andere leerkrachten er ook gebruik van maken (net zoals jij de keuze hebt uit duizenden publieke oefeningen op Dodona).
 


### PR DESCRIPTION
This allows people to copy the examples without depending on a `dirconfig.json`.