### PR TITLE
Fix typos and grammar issues

### DIFF
--- a/[path].paths.ts
+++ b/[path].paths.ts
@@ -24,7 +24,7 @@ const redirects = internationalizedRedirects({
     'guides/getting-started': 'guides/teachers/getting-started',
     'ufora': 'guides/teachers/ufora',
 
-    // Backwards compatability to not break existing URls.
+    // Backwards compatibility to not break existing URLs.
     // Especially important for published URLs.
     'tested': 'references/tested',
     'tested/json': 'references/tested/json',

--- a/en/faq/accounts/index.md
+++ b/en/faq/accounts/index.md
@@ -36,4 +36,4 @@ Dodona automatically gets your name and email from the login provider (e.g. Smar
 
 ## I get a warning that my time zone is wrong, what should I do?
 
-All deadlines on Dodona are displayed in your local time. To do this, Dodona needs to associate a time zone with your account. If we detect that the timezone of your browser is different from the timezone of your account, we will show a warning. You can change your timezone in your [Account Settings] (https://dodona.ugent.be/en/profile).
+All deadlines on Dodona are displayed in your local time. To do this, Dodona needs to associate a time zone with your account. If we detect that the timezone of your browser is different from the timezone of your account, we will show a warning. You can change your timezone in your [Account Settings](https://dodona.ugent.be/en/profile).

--- a/en/faq/annotations/index.md
+++ b/en/faq/annotations/index.md
@@ -59,7 +59,7 @@ You will also see a notification in the top navigation bar of your course. Click
 
 ![img.png](./course_question_list.png)
 
-If you want to see al open question across all your courses, you can go to the `Questions` page in the navigation sidebar of Dodona.
+If you want to see all open questions across all your courses, you can go to the `Questions` page in the navigation sidebar of Dodona.
 
 ![img.png](./questions_index_page.png)
 
@@ -110,7 +110,7 @@ Saved comments are scoped by course and by exercise by default. This way we are 
 If you want to reuse a comment across your whole course, or even across multiple courses, you can edit the saved comment and remove the course and/or exercise limitations. This way the comment will be suggested in all exercises of all your courses.
 ![edit_saved_comment.png](edit_saved_comment.png)
 
-To edit a saved comment, click on the saved comment icon on an annotation wich reuses the comment. This will open the saved comment and clicking the pencil icon will allow you to edit the comment.
+To edit a saved comment, click on the saved comment icon on an annotation which reuses the comment. This will open the saved comment and clicking the pencil icon will allow you to edit the comment.
 ![saved_comment_link.png](saved_comment_link.png)
 
 You can find an overview of all your saved comments for a certain exercise by clicking the link underneath the search field. Or by clicking on 'saved comments' in the sidebar menu.

--- a/en/faq/index.md
+++ b/en/faq/index.md
@@ -23,7 +23,7 @@ In this FAQ section you will find answers to the most frequently asked questions
 - [How do I create new exercises?](./activities/#how-do-i-create-new-exercises)
 
 ## Featured courses
-- [What is a featured courses?](./featured-courses/#what-is-a-featured-course)
+- [What is a featured course?](./featured-courses/#what-is-a-featured-course)
 - [I made a course, how can I get it featured?](./featured-courses/#i-made-a-course-how-can-i-get-it-featured)
 - [How can I use a featured course?](./featured-courses/#how-can-i-use-a-featured-course)
 - [Which featured courses are available?](./featured-courses/#which-featured-courses-are-available)

--- a/en/guides/exercises/creating-exercises/exercise/index.md
+++ b/en/guides/exercises/creating-exercises/exercise/index.md
@@ -37,7 +37,7 @@ If everything went well, this window should now be empty.
 
 ## 6. Testing the Exercise
 
-The exercise you just created can be found in [your exercise repository](https://dodona.be/nl/repositories/) on Dodona.
+The exercise you just created can be found in [your exercise repository](https://dodona.be/en/repositories/) on Dodona.
 Your new exercise is now available as a _concept_ on Dodona.
 
 Before you can publish an exercise (removing it from concept status), Dodona checks whether three conditions are met:

--- a/en/guides/general/getting-started/index.md
+++ b/en/guides/general/getting-started/index.md
@@ -16,5 +16,5 @@ At the moment, Dodona supports more than 20 programming languages, including Pyt
 
 Depending on your role, we have a specific guide for you:
 
-- [Getting started for students](/nl/guides/students/getting-started)
-- [Getting started for teachers](/nl/guides/teachers/getting-started)
+- [Getting started for students](/en/guides/students/getting-started)
+- [Getting started for teachers](/en/guides/teachers/getting-started)

--- a/en/references/judges/creating-a-judge/index.md
+++ b/en/references/judges/creating-a-judge/index.md
@@ -106,7 +106,7 @@ The full output returns a single JSON at the end. You must ensure that this is e
   - `permission`, a string specifying the visibility of this message. The permission can be any of
     - `"student"`, which makes the message visible for everyone;
     - `"staff"`, which makes the message visible only for staff members (e.g. for judge debug output);
-    - `"zeus"`, which make is visible only for almighty Zeus (e.g. for application debug output);
+    - `"zeus"`, which makes it visible only for almighty Zeus (e.g. for application debug output);
 
 - A `Status` string indicates the status of the submission. They can be separated in two categories
   - Available for output by the judge:

--- a/en/references/judges/python-judge/index.md
+++ b/en/references/judges/python-judge/index.md
@@ -55,7 +55,7 @@ De normale werking van de judge bestaat per geüploade testcase uit een aantal s
 - Per blok wordt uitvoer gegenereerd aan de hand van de ingediende code en de invoer uit het blok.
 - De verwachte en gegenereerde uitvoer per blok worden met elkaar vergeleken.
 
-Als er fouten (of runtime-errors/time limit exceeded) tegengekomen worden stopt de judge daar en wordt feedback teruggegeven (in de vorm van een tabel met aangeduide verschillen tussen verwachte en gegenereerde uitvoer). Als daarentegen alle blokken correct waren, wordt ook nog eens voor de volledige input gekeken of de gegeneerde output overeenkomt met de verwachte uitvoer en wordt daarna feedback teruggegeven over deze laatste vergelijking.
+Als er fouten (of runtime-errors/time limit exceeded) tegengekomen worden stopt de judge daar en wordt feedback teruggegeven (in de vorm van een tabel met aangeduide verschillen tussen verwachte en gegenereerde uitvoer). Als daarentegen alle blokken correct waren, wordt ook nog eens voor de volledige input gekeken of de gegenereerde output overeenkomt met de verwachte uitvoer en wordt daarna feedback teruggegeven over deze laatste vergelijking.
 
 De default werking van de judge kan veranderd worden aan de hand van een aantal parameters. Deze moeten toegevoegd worden aan het bestand met verwachte uitvoer na één enkele regel die enkel bestaat uit koppeltekens (minstens 3).
 
@@ -222,7 +222,7 @@ Standaard zal de doctest judge enkel returnwaarden vergelijken. Met de parameter
 >>> # Het volgende is correct:
 >>> my_print(5) #doctest: +STDOUT
 5
->>> # Als we de 'STDOUT' optievlag toevoegen zal er gecontroleerd worden dat None terugegeven worden.
+>>> # Als we de 'STDOUT' optievlag toevoegen zal er gecontroleerd worden dat None teruggegeven worden.
 >>> # Als we zowel de prints als de returnwaarde willen voegen we ze beide expliciet toe:
 >>> my_print(5) #doctest: +STDOUT, +RETURN
 5

--- a/nl/guides/teachers/course-management/index.md
+++ b/nl/guides/teachers/course-management/index.md
@@ -51,7 +51,7 @@ Deze oplossingen kan je ook op andere manieren bereiken:
 * Een overzicht van de oplossingen voor een **specifieke oefening** vind je door op de cursuspagina op het pijltje rechts van een oefening te klikken.
 * Een overzicht van de oplossingen voor **specifieke gebruiker** vind je door op `Oplossingen` te klikken op de [cursuspagina van die gebruiker](../user-management/#studenten-opvolgen).
 
-In het oplossingenoverzicht vindt je rechts van de filterbalk een knop met 3 puntjes. In het menu vindt je enkele acties en filter:
+In het oplossingenoverzicht vind je rechts van de filterbalk een knop met 3 puntjes. In het menu vind je enkele acties en filter:
 
 * `Meest recente correcte oplossing per gebruiker`: Beperkt het overzicht tot de meest recente correcte oplossing per gebruiker.
 

--- a/nl/guides/teachers/getting-started/index.md
+++ b/nl/guides/teachers/getting-started/index.md
@@ -53,7 +53,7 @@ Nadat je een reeks hebt aangemaakt, kan je oefeningen en leesactiviteiten toevoe
 
 ![oefening-toevoegen](./oefening-toevoegen.png)
 
-Bij het selecteren van oefeningen kun je meer info over een oefening bekijken door naar de infopagina te gaan. Hier vindt je voorbeeldoplossingen, beschikbare talen, instellingen, extra uitleg en contactgegevens van de auteur.
+Bij het selecteren van oefeningen kun je meer info over een oefening bekijken door naar de infopagina te gaan. Hier vind je voorbeeldoplossingen, beschikbare talen, instellingen, extra uitleg en contactgegevens van de auteur.
 
 ![oefening-infopagina](./oefening-infopagina.png)
 

--- a/nl/guides/teachers/grading/index.md
+++ b/nl/guides/teachers/grading/index.md
@@ -18,7 +18,7 @@ Rechts onderaan de reeks vind je een knop om een nieuwe evaluatie voor die reeks
 
 ## Je evaluatie configureren
 
-Voor je kan beginnen met verbeteren moet je eerst de evaluatie configureren. Je moet bijvoorbeeld selecteren welke studenten je wil opnemen en of je een puntenverdeling per oefening wil instellen. Bij het aanmaken wordt je door de verschillende stappen gegidst.
+Voor je kan beginnen met verbeteren moet je eerst de evaluatie configureren. Je moet bijvoorbeeld selecteren welke studenten je wil opnemen en of je een puntenverdeling per oefening wil instellen. Bij het aanmaken word je door de verschillende stappen gegidst.
 
 ### Een deadline kiezen
 

--- a/nl/references/judges/creating-a-judge/index.md
+++ b/nl/references/judges/creating-a-judge/index.md
@@ -106,7 +106,7 @@ The full output returns a single JSON at the end. You must ensure that this is e
   - `permission`, a string specifying the visibility of this message. The permission can be any of
     - `"student"`, which makes the message visible for everyone;
     - `"staff"`, which makes the message visible only for staff members (e.g. for judge debug output);
-    - `"zeus"`, which make is visible only for almighty Zeus (e.g. for application debug output);
+    - `"zeus"`, which makes it visible only for almighty Zeus (e.g. for application debug output);
 
 - A `Status` string indicates the status of the submission. They can be separated in two categories
   - Available for output by the judge:

--- a/nl/references/judges/python-judge/index.md
+++ b/nl/references/judges/python-judge/index.md
@@ -58,7 +58,7 @@ De normale werking van de judge bestaat per geüploade testcase uit een aantal s
 - Per blok wordt uitvoer gegenereerd aan de hand van de ingediende code en de invoer uit het blok.
 - De verwachte en gegenereerde uitvoer per blok worden met elkaar vergeleken.
 
-Als er fouten (of runtime-errors/time limit exceeded) tegengekomen worden stopt de judge daar en wordt feedback teruggegeven (in de vorm van een tabel met aangeduide verschillen tussen verwachte en gegenereerde uitvoer). Als daarentegen alle blokken correct waren, wordt ook nog eens voor de volledige input gekeken of de gegeneerde output overeenkomt met de verwachte uitvoer en wordt daarna feedback teruggegeven over deze laatste vergelijking.
+Als er fouten (of runtime-errors/time limit exceeded) tegengekomen worden stopt de judge daar en wordt feedback teruggegeven (in de vorm van een tabel met aangeduide verschillen tussen verwachte en gegenereerde uitvoer). Als daarentegen alle blokken correct waren, wordt ook nog eens voor de volledige input gekeken of de gegenereerde output overeenkomt met de verwachte uitvoer en wordt daarna feedback teruggegeven over deze laatste vergelijking.
 
 De default werking van de judge kan veranderd worden aan de hand van een aantal parameters. Deze moeten onderaan toegevoegd worden aan het bestand met verwachte uitvoer na één enkele regel die enkel bestaat uit koppeltekens (minstens 3).
 
@@ -225,7 +225,7 @@ Standaard zal de doctest judge enkel returnwaarden vergelijken. Met de parameter
 >>> # Het volgende is correct:
 >>> my_print(5) #doctest: +STDOUT
 5
->>> # Als we de 'STDOUT' optievlag toevoegen zal er gecontroleerd worden dat None terugegeven worden.
+>>> # Als we de 'STDOUT' optievlag toevoegen zal er gecontroleerd worden dat None teruggegeven worden.
 >>> # Als we zowel de prints als de returnwaarde willen voegen we ze beide expliciet toe:
 >>> my_print(5) #doctest: +STDOUT, +RETURN
 5


### PR DESCRIPTION
I was playing with OpenAI Codex and used it to find and fix some typos in our documentation.