### PR TITLE
Update 'Granting Dodona Access' sections to reflect automated GitHub invitation acceptance

### DIFF
--- a/en/guides/exercises/creating-exercises/setup/index.md
+++ b/en/guides/exercises/creating-exercises/setup/index.md
@@ -71,9 +71,9 @@ The easiest way to do this (on github.com) is to give the user [dodona-server](h
 GitHub will then send an invitation that the Dodona team needs to accept.
 Once the invitation is accepted, you can proceed to the next steps.
 
-::: warning Manual Approval
-A member of the Dodona team must manually accept the invitation on GitHub.
-This may take some time, so please be patient.
+::: warning Note
+The acceptance process is automated, but it can take up to half an hour before your invitation is accepted.
+If it's taking longer and you still don't see _dodona-server_ in the list of collaborators, please [contact the Dodona team](https://dodona.be/en/contact).
 :::
 
 ### Adding the Repository to Dodona

--- a/en/guides/exercises/new-exercise-repo/index.md
+++ b/en/guides/exercises/new-exercise-repo/index.md
@@ -24,8 +24,11 @@ In the creation form, choose a (preferably unique) name for your repository on D
 
 Before clicking on the add button, make sure the Dodona server has both read and write access to your exercise repository. We need this access to be able to edit the exercises through the Dodona web-interface.
 
-On github.com, the easiest way to do this is by adding the user [dodona-server](https://github.com/dodona-server) to your repository. From the moment we accept this invitation, you can get started. On github.ugent.be, add [SA-GitHubDodona](https://github.ugent.be/SA-GitHubDodona). On gitlab.com, add [dodona-server](https://gitlab.com/dodona-server). If the repository is hosted on a self-hosted GitLab server, you will have to create a new user for Dodona on the GitLab instance, add our [ssh public key](/dodona.pub) to that user, and add that user as collaborator to the repository (with write access).
-
+- On github.com, invite the user [dodona-server](https://github.com/dodona-server) to your repository as a collaborator. Once the invitation is accepted, you can get started. The acceptance is automated, but can take up to half an hour. Is it taking longer? [Contact Team Dodona](https://dodona.be/en/contact).
+- On github.ugent.be, add [SA-GitHubDodona](https://github.ugent.be/SA-GitHubDodona).
+- On gitlab.com, add [dodona-server](https://gitlab.com/dodona-server) as a member to your project.
+- For self-hosted GitLab servers, create a new user for Dodona, add our [SSH public key](/dodona.pub) to that user, and grant write access to your repository.
+ 
 ![github add collaborator](./github-add-collab.png)
 
 You can now click the add-button on Dodona to add your repository.

--- a/nl/guides/exercises/creating-exercises/setup/index.md
+++ b/nl/guides/exercises/creating-exercises/setup/index.md
@@ -71,9 +71,9 @@ De makkelijkste manier om dit te doen (op github.com) is de gebruiker [dodona-se
 GitHub zal dan een uitnodiging sturen die Team Dodona moet aanvaarden.
 Eens de uitnodiging aanvaard is, kan je verder gaan met de volgende stappen.
 
-::: warning Manueel werk
-Een lid van Team Dodona moet de uitnodiging van GitHub manueel aanvaarden.
-Daardoor kan het soms even duren eer dat gebeurt.
+::: warning Opgepast
+De uitnodiging van GitHub wordt automatisch door Team Dodona aanvaard. Dit kan tot een half uur duren.
+Zie je de gebruiker _dodona-server_ na een half uur nog steeds niet in de lijst van _Collaborators_ staan? [Neem dan contact op met Team Dodona](https://dodona.be/nl/contact).
 :::
 
 ### Repository toevoegen aan Dodona

--- a/nl/guides/exercises/new-exercise-repo/index.md
+++ b/nl/guides/exercises/new-exercise-repo/index.md
@@ -22,10 +22,13 @@ In het formulier om de repository toe te voegen kies je een unieke naam voor je 
 
 ![github clone url](./github-clone-url.png)
 
-Voordat je op de toevoeg-knop klikt, moet je er eerst voor zorgen dat de Dodona server zowel lees- als schrijfrechten heeft op je repository met oefeningen. We hebben deze schrijftoegang nodig om eenvoudig de oefeningen kunnen bewerken via de webinterface.
+Voordat je op de toevoeg-knop klikt, moet je er eerst voor zorgen dat de Dodona server zowel lees- als schrijfrechten heeft op je repository met oefeningen. We hebben deze schrijftoegang nodig om eenvoudig de oefeningen te kunnen bewerken via de webinterface.
 
-Op github.com is de eenvoudigste manier om de gebruiker [dodona-server](https://github.com/dodona-server) aan je repository toe te voegen. Van zodra wij deze uitnodiging accepteren, kan je van start gaan. Op github.ugent.be voeg je op dezelfde wijze de gebruiker [SA-GitHubDodona](https://github.ugent.be/SA-GitHubDodona) toe. Op gitlab.com kan je [dodona-server](https://gitlab.com/dodona-server) toevoegen. Als je je repository op een eigen GitLab server host, dan zal je zelf een nieuwe gebruiker voor Dodona moeten aanmaken. Je kan onze [publieke ssh sleutel](/dodona.pub) hiervoor gebruiken.
-
+- Op github.com voeg je eenvoudig de gebruiker [dodona-server](https://github.com/dodona-server) toe aan je repository. Zodra wij de uitnodiging accepteren (binnen het half uur), kan je aan de slag. De acceptatie gebeurt automatisch, maar kan tot een half uur duren. Duurt het toch langer, [neem dan contact op met Team Dodona](https://dodona.be/nl/contact).
+- Op github.ugent.be voeg je [SA-GitHubDodona](https://github.ugent.be/SA-GitHubDodona) toe.
+- Op gitlab.com gebruik je [dodona-server](https://gitlab.com/dodona-server).
+- Host je op een eigen GitLab server, maak dan zelf een gebruiker voor Dodona aan en gebruik onze [publieke ssh sleutel](/dodona.pub).
+ 
 ![github gebruiker toevoegen](./github-add-collab.png)
 
 Je kan op de Dodona website het toevoegen van de repository nu finaliseren.


### PR DESCRIPTION
Related to https://github.com/dodona-edu/dodona/issues/6144, updates the docs now that we have automated collaboration invite acceptance again.

We schedule the jobs every 10 minutes, but this is just an indication to GitHub. Looking at the latest runs, it can take up to +- 25 minutes in between runs, so mentioning 30 gives the user an indication while also not overpromising the time it can take.

<img width="203" height="374" alt="image" src="https://github.com/user-attachments/assets/526c67a8-0db7-41c0-800f-61c8ab1b55b8" />

Open for any rewordings, this is the best GPT 4.1 could come up with that I found acceptable 😄 
