### PR TITLE
Remove the outdated options.mode setting from the TESTed docs

### DIFF
--- a/en/references/tested/exercise-config/index.md
+++ b/en/references/tested/exercise-config/index.md
@@ -28,47 +28,25 @@ See the reference documentation for the [DSL test suites](/en/references/tested/
 The `evaluation` block can contain an `options` object with attributes that influence the general behaviour of TESTed.
 We discuss each of these options below.
 
-### `options.mode`
-
-The `mode` attribute indicates how test code is generated and compiled (along with submissions).
-Two modes are supported:
-
-* `batch` (default): All test code in a tab is generated and compiled in a single compilation unit (batch compilation).
-* `context`: Test code is generated and compiled per context (contextual compilation).
-
-The compilation process is faster with batch compilation than with contextual compilation,
-but may fail if a submission does not implement all requirements of the exercise.
-For example, if an exercise requires a student to implement two functions,
-but a submission only implements a single function, this will result in a compilation error for Java submissions.
-See the next attribute for a workaround.
-
-Here's an example that uses contextual compilation:
-
-```json
-{
-  "evaluation": {
-    "options": {
-      "mode": "context"
-    }
-  }
-}
-```
-
 ### `options.allow_fallback`
 
-When the boolean attribute `allow_fallback` is set to true (the default value),
-TESTed automatically falls back to contextual compilation when batch compilation fails.
+By default, TESTed generates and compiles all test code of a tab together in a single compilation unit (*batch compilation*).
+This is fast, but it can fail if a submission does not implement all requirements of the exercise.
+For example, if an exercise requires a student to implement two functions,
+but a submission only implements a single function, this will result in a compilation error for Java submissions.
+
+When the boolean attribute `allow_fallback` is set to `true` (the default value),
+TESTed automatically falls back to compiling the test code per context (*contextual compilation*) when batch compilation fails.
 This may be useful with submissions that do not implement all requirements of the exercise.
 
-Here's an example that disables falling back to contextual compilation:
+Here's an example that disables this fallback:
 
 ```json
 {
   "evaluation": {
     "options": {
-      "mode": "batch",
       "allow_fallback": false
-    }   
+    }
   }
 }
 ```
@@ -276,7 +254,6 @@ Here's an example of a complete configuration file (`config.json`) for a Dodona 
     "handler": "TESTed",
     "test_suite": "suite.yaml",
     "options": {
-      "mode": "batch",
       "allow_fallback": true,
       "linter": {
         "c": true,

--- a/nl/references/tested/exercise-config/index.md
+++ b/nl/references/tested/exercise-config/index.md
@@ -27,46 +27,24 @@ Zie [_Formaat voor testplannen_](/nl/references/tested/json) voor een gedetaille
 Het `evaluation`-blok ondersteunt een `option`-object met velden die het gedrag van TESTed beïnvloeden.
 We overlopen deze opties hieronder.
 
-### `options.mode`
-
-Het veld `mode` geeft aan hoe testcode gegenereerd en uitgevoerd moeten worden (samen met de ingediende oplossing).
-Twee modi worden ondersteund:
-
-* `batch` (standaard): Alle testcode van een tabblad wordt gegenereerd en gecompileerd in één compilatie-eenheid (batchcompilatie).
-* `context`: Testcode wordt gegenereerd en gecompileerd per context (contextuele compilatie).
-
-Het compilatieproces is sneller bij batchcompilatie dan met contextuele compilatie,
-maar kan falen als een ingediende oplossing niet aan alle vereisten van de oefening voldoet.
-Als een oefening bijvoorbeeld vereist dat twee functie geïmplementeerd worden, maar de ingediende oplossing implementeert er slechts één, zal dit bij oplossingen in Java leiden tot compilatiefouten.
-Zie het volgende veld voor een oplossing.
-
-Hier is een voorbeeld dat contextuele compilatie gebruikt:
-
-```json
-{
-  "evaluation": {
-    "options": {
-      "mode": "context"
-    }
-  }
-}
-```
-
 ### `options.allow_fallback`
 
+Standaard genereert en compileert TESTed alle testcode van een tabblad samen in één compilatie-eenheid (*batchcompilatie*).
+Dat is snel, maar kan falen als een ingediende oplossing niet aan alle vereisten van de oefening voldoet.
+Als een oefening bijvoorbeeld vereist dat twee functies geïmplementeerd worden, maar de ingediende oplossing implementeert er slechts één, zal dit bij oplossingen in Java leiden tot compilatiefouten.
+
 Als het Booleaanse veld `allow_fallback` op `true` staat (de standaardwaarde),
-zal TESTed automatisch contextuele compilatie gebruiken als de batchcompilatie faalt.
+valt TESTed automatisch terug op het per context compileren van de testcode (*contextuele compilatie*) wanneer de batchcompilatie faalt.
 Dit kan nuttig zijn om ingediende oplossingen te evalueren die niet alle vereisten implementeren.
 
-Hier is een voorbeeld dat het terugvallen op de contextuele compilatie uitschakelt:
+Hier is een voorbeeld dat dit terugvallen uitschakelt:
 
 ```json
 {
   "evaluation": {
     "options": {
-      "mode": "batch",
       "allow_fallback": false
-    }   
+    }
   }
 }
 ```
@@ -270,7 +248,6 @@ Hieronder is een voorbeeld van een volledig configuratiebestand (`config.json`) 
     "handler": "TESTed",
     "plan_name": "plan.json",
     "options": {
-      "mode": "batch",
       "allow_fallback": true,
       "linter": {
         "c": true,


### PR DESCRIPTION
The `options.mode` setting (`batch` / `context`) documented for TESTed is dead config: it's still parsed into the config, but the judge stopped reading it in dodona-edu/universal-judge#437 ("Rework execution"), which replaced mode-driven grouping with a hardcoded `PlanStrategy`. Setting it has no effect, so this removes it from the EN and NL exercise-config pages.

`options.allow_fallback` is still live and still controls the batch-to-per-context compilation fallback, so I kept that section and folded the still-relevant "batch compilation can fail if a submission doesn't implement everything" explanation into it (it used to live in the `mode` section).

Also dropped the stray `"mode": "batch"` from the two `options` examples.


Updates https://github.com/dodona-edu/dodona/issues/8522